### PR TITLE
Successfully build on macOS

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -38,3 +38,36 @@ Quick Start
 sudo pacman -S git lilv suil lv2 ladspa boost
 ```
 If you get crazy looking errors with `waf configure` then try specifying python2 e.g. `python2 waf configure` and so on.
+
+#### macOS
+Make sure you're running Python 2.
+```
+python --version
+```
+
+Install [Boost](https://www.boost.org/) using [Homebrew](https://docs.brew.sh/).
+```
+brew install boost
+```
+
+Build
+```
+./waf configure
+./waf build
+```
+
+Test
+```
+LD_LIBRARY_PATH="`pwd`/build/lib" build/bin/test-element
+```
+
+Release build
+```
+./waf install
+```
+
+This produces `build/Applications/Element.app`.
+
+```
+open build/Applications/Element.app
+```

--- a/src/CommonConfig.h
+++ b/src/CommonConfig.h
@@ -53,9 +53,3 @@
 #if !defined(EL_FREE) && !defined(EL_SOLO)
  #define EL_PRO 1
 #endif
-
-#if JUCE_LINUX
- #define JLV2_PLUGINHOST_LV2 1
-#else
- #define JLV2_PLUGINHOST_LV2 0
-#endif

--- a/src/CommonConfig.h
+++ b/src/CommonConfig.h
@@ -53,3 +53,9 @@
 #if !defined(EL_FREE) && !defined(EL_SOLO)
  #define EL_PRO 1
 #endif
+
+#if JUCE_LINUX
+ #define JLV2_PLUGINHOST_LV2 1
+#else
+ #define JLV2_PLUGINHOST_LV2 0
+#endif

--- a/tools/waf/element.py
+++ b/tools/waf/element.py
@@ -35,7 +35,7 @@ def check_common (self):
     self.check_cfg(package='lilv-0', uselib_store="LILV", args='--cflags --libs', mandatory=False)
     self.check_cfg(package='suil-0', uselib_store="SUIL", args='--cflags --libs', mandatory=False)
     self.env.LV2 = bool(self.env.HAVE_LILV) and bool(self.env.HAVE_LILV)
-    self.define('KV_LV2_PLUGIN_HOST', self.env.LV2)
+    self.define('JLV2_PLUGINHOST_LV2', self.env.LV2)
 
 @conf
 def check_mingw (self):


### PR DESCRIPTION
During `waf build`, I was getting the following error:

```
In file included from ../libs/compat/include_jlv2_host.cpp:9:
../libs/jlv2/modules/jlv2_host/jlv2_host.cpp:32:10: fatal error: 'lv2/lv2plug.in/ns/lv2core/lv2.h' file not found
#include <lv2/lv2plug.in/ns/lv2core/lv2.h>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This PR defines `JLV2_PLUGINHOST_LV2` to `0` when not building for Linux. I put the declaration in `CommonConfig.h`, I hope that's the right place for it. With this change, I was able to successfully build on macOS.

I also added a few notes to help others. Aside from the above point, the tricky parts for me were figuring out that Python 2 is required, and that Boost needs to be installed - the easiest way was by using the Homebrew package manager.