### PR TITLE
Display "no device" on MIDI In Node When No Enabled Device

### DIFF
--- a/data/Sessions/Default.els
+++ b/data/Sessions/Default.els
@@ -2,13 +2,43 @@
 
 <session name="" tempo="120.0" notes="" beatsPerBar="4" beatDivisor="2">
   <graphs active="0">
-    <node type="graph" uuid="7fb0bf634f0b4b5aa052670d2d58fe21" name="Graph"
+    <node type="graph" uuid="137dde976f8f488d8095aa2f870cecf4" name="Graph"
           bypass="0" persistent="1" renderMode="single" keyStart="0" keyEnd="127"
           transpose="0">
       <nodes>
+        <node id="1" type="plugin" format="Internal" identifier="audio.input"
+              name="Built-in Microphone" relativeX="0.25" relativeY="0.25"
+              numAudioIns="0" numAudioOuts="2" uuid="0464889fc52641b195d6b2d275b1ea83"
+              bypass="0" persistent="1" renderMode="single" keyStart="0" keyEnd="127"
+              transpose="0" enabled="1" program="0" midiProgram="0" globalMidiPrograms="0"
+              midiProgramsEnabled="0" mute="0" muteInput="0" midiProgramsState="">
+          <nodes/>
+          <ui/>
+          <ports>
+            <port index="0" channel="0" type="audio" name="Input 1" symbol="audio_out_1"
+                  flow="output"/>
+            <port index="1" channel="1" type="audio" name="Input 2" symbol="audio_out_2"
+                  flow="output"/>
+          </ports>
+        </node>
+        <node id="2" type="plugin" format="Internal" identifier="audio.output"
+              name="Built-in Output" relativeX="0.25" relativeY="0.75" numAudioIns="2"
+              numAudioOuts="0" uuid="d1d921c881374d5abfbb41fad3d735a7" bypass="0"
+              persistent="1" renderMode="single" keyStart="0" keyEnd="127"
+              transpose="0" enabled="1" program="0" midiProgram="0" globalMidiPrograms="0"
+              midiProgramsEnabled="0" mute="0" muteInput="0" midiProgramsState="">
+          <nodes/>
+          <ui/>
+          <ports>
+            <port index="0" channel="0" type="audio" name="Output 1" symbol="audio_in_1"
+                  flow="input"/>
+            <port index="1" channel="1" type="audio" name="Output 2" symbol="audio_in_2"
+                  flow="input"/>
+          </ports>
+        </node>
         <node id="3" type="plugin" format="Internal" identifier="midi.input"
               name="MIDI In" relativeX="0.75" relativeY="0.25" numAudioIns="0"
-              numAudioOuts="0" uuid="c4a6237a7e124430999cf2a7365a8004" bypass="0"
+              numAudioOuts="0" uuid="c2810d5c11724ca98e75026fb92c6d52" bypass="0"
               persistent="1" renderMode="single" keyStart="0" keyEnd="127"
               transpose="0" enabled="1" program="0" midiProgram="0" globalMidiPrograms="0"
               midiProgramsEnabled="0" mute="0" muteInput="0" midiProgramsState="">
@@ -21,7 +51,7 @@
         </node>
         <node id="4" type="plugin" format="Internal" identifier="midi.output"
               name="MIDI Out" relativeX="0.75" relativeY="0.75" numAudioIns="0"
-              numAudioOuts="0" uuid="9b3f22d176de41d696f5c66ce857ea8b" bypass="0"
+              numAudioOuts="0" uuid="f152de9a762047c0b8a5f9d097058546" bypass="0"
               persistent="1" renderMode="single" keyStart="0" keyEnd="127"
               transpose="0" enabled="1" program="0" midiProgram="0" globalMidiPrograms="0"
               midiProgramsEnabled="0" mute="0" muteInput="0" midiProgramsState="">
@@ -40,5 +70,5 @@
   </graphs>
   <controllers/>
   <maps/>
-  <ui content="128.3ocAA2sBBCBF..UunWGIXwpaGqI4ZzOTYpvtHPGoyzv9X5iemyO3EXPX7on1zosPL0FCfI.bqIiviqpqIUwc8fa+Q1CpvE2VN2McuOqJdWPRkoMLk9KU4XdQpgqhyrO9qLEj8R0atXpwubIO6jE4SV6P4vsABY8REwhP+4nnpXD"/>
+  <ui/>
 </session>

--- a/src/engine/MidiEngine.cpp
+++ b/src/engine/MidiEngine.cpp
@@ -283,6 +283,15 @@ void MidiEngine::processMidiBuffer (const MidiBuffer& buffer, int nframes, doubl
     }
 }
 
+int MidiEngine::getNumActiveMidiInputs() const
+{
+    int total = 0;
+    for (const auto& dev : MidiInput::getDevices())
+        if (isMidiInputEnabled (dev))
+            ++total;
+    return total;
+}
+
 //==============================================================================
 void MidiEngine::setDefaultMidiOutput (const String& deviceName)
 {

--- a/src/engine/MidiEngine.h
+++ b/src/engine/MidiEngine.h
@@ -85,6 +85,9 @@ public:
      */
     void removeMidiInputCallback (MidiInputCallback* callback);
 
+    /** Returns the number of enabled midi inputs */
+    int getNumActiveMidiInputs() const;
+    
     //==============================================================================
     /** Sets a midi output device to use as the default.
 

--- a/src/gui/GraphEditorComponent.cpp
+++ b/src/gui/GraphEditorComponent.cpp
@@ -599,26 +599,37 @@ public:
         g.setColour (Colours::black);
         g.setFont (font);
         
+        auto displayName = node.getDisplayName();
+        auto subName = node.hasModifiedName() ? node.getPluginName() : String();
+        
+        if (node.isMidiInputNode())
+        {
+            auto& midi = ViewHelpers::getGlobals(this)->getMidiEngine();
+            if (midi.getNumActiveMidiInputs() <= 0)
+                subName = "(no device)";
+        }
+
         if (vertical)
         {
-            g.drawFittedText (node.getDisplayName(), box.getX() + 9, box.getY() + 2, box.getWidth(),
+            g.drawFittedText (displayName, box.getX() + 9, box.getY() + 2, box.getWidth(),
                                          18, Justification::centredLeft, 2);
-            if (node.hasModifiedName())
+
+            if (subName.isNotEmpty())
             {
                 g.setFont (Font (8.f));
-                g.drawFittedText (node.getPluginName(), box.getX() + 9, box.getY() + 10, box.getWidth(),
-                                                  18, Justification::centredLeft, 2);
+                g.drawFittedText (subName, box.getX() + 9, box.getY() + 10, box.getWidth(),
+                                  18, Justification::centredLeft, 2);
             }
         }
         else
         {
-            g.drawFittedText (node.getDisplayName(), box.getX() + 20, box.getY() + 2, box.getWidth(),
-                                                     18, Justification::centredLeft, 2);
-            if (node.hasModifiedName())
+            g.drawFittedText (displayName, box.getX() + 20, box.getY() + 2, box.getWidth(),
+                                           18, Justification::centredLeft, 2);
+            if (subName.isNotEmpty())
             {
                 g.setFont (Font (8.f));
-                g.drawFittedText (node.getPluginName(), box.getX() + 20, box.getY() + 10, box.getWidth(),
-                                                  18, Justification::centredLeft, 2);
+                g.drawFittedText (subName, box.getX() + 20, box.getY() + 10, box.getWidth(),
+                                  18, Justification::centredLeft, 2);
             }
         }
         

--- a/src/gui/GraphEditorComponent.cpp
+++ b/src/gui/GraphEditorComponent.cpp
@@ -1393,6 +1393,13 @@ void GraphEditorComponent::updateFilterComponents (const bool doPosition)
             { fc->update (doPosition); }
 }
 
+void GraphEditorComponent::stabilizeNodes()
+{
+    for (int i = getNumChildComponents(); --i >= 0;)
+        if (auto* const fc = dynamic_cast<FilterComponent*> (getChildComponent (i)))
+            { fc->update (false); fc->repaint(); }
+}
+
 void GraphEditorComponent::updateComponents()
 {
     for (int i = graph.getNumConnections(); --i >= 0;)

--- a/src/gui/GraphEditorComponent.h
+++ b/src/gui/GraphEditorComponent.h
@@ -75,6 +75,10 @@ public:
     }
 
     Node getGraph() const { return graph; }
+
+    /** Stabilize all nodes without changing position */
+    void stabilizeNodes();
+
 protected:
     virtual Component* wrapAudioProcessorEditor (AudioProcessorEditor* ed, GraphNodePtr editorNode);
     void createNewPlugin (const PluginDescription* desc, int x, int y);

--- a/src/gui/views/GraphEditorView.h
+++ b/src/gui/views/GraphEditorView.h
@@ -25,7 +25,8 @@
 
 namespace Element {
 
-class GraphEditorView : public GraphDisplayView
+class GraphEditorView : public GraphDisplayView,
+                        public ChangeListener
 {
 public:
     GraphEditorView();
@@ -38,6 +39,8 @@ public:
     void paint (Graphics& g) override;
 
     bool keyPressed (const KeyPress& key, Component* c) override;
+
+    void changeListenerCallback (ChangeBroadcaster*) override;
 
 protected:
     void graphDisplayResized (const Rectangle<int>& area) override;

--- a/src/session/Node.h
+++ b/src/session/Node.h
@@ -278,12 +278,14 @@ public:
                 objectData.getProperty(Tags::identifier) == "midi.output");
     }
     
+    /** Returns true if a global MIDI input node. e.g */
     inline bool isMidiInputNode() const
     {
         return objectData.getProperty(Tags::format) == "Internal" &&
             objectData.getProperty(Tags::identifier) == "midi.input";
     }
 
+    /** Returns true if a global MIDI output node. e.g */
     inline bool isMidiOutputNode() const
     {
         return objectData.getProperty(Tags::format) == "Internal" &&


### PR DESCRIPTION
Visual feedback to the user to avoid confusion and hint that a MIDI device needs enabled.