### PR TITLE
Add oversampling option for plugins

### DIFF
--- a/src/engine/GraphNode.h
+++ b/src/engine/GraphNode.h
@@ -144,7 +144,7 @@ public:
     void suspendProcessing (const bool);
 
     /** Get latency audio samples */
-    int getLatencySamples() const { return latencySamples; }
+    int getLatencySamples() const { return latencySamples + roundFloatToInt (osLatency); }
 
     /** Set latency samples */
     void setLatencySamples (int latency) { if (latencySamples != latency) latencySamples = latency; }
@@ -325,6 +325,13 @@ public:
     Signal<void(GraphNode*)> muteChanged;
     Signal<void()> willBeRemoved;
 
+    void initOversampling (int numChannels, int blockSize);
+    void prepareOversampling (int blockSize);
+    void resetOversampling();
+    dsp::Oversampling<float>* getOversamplingProcessor();
+    void setOversamplingFactor (int osFactor);
+    int getOversamplingFactor();
+
 protected:
     GraphNode (uint32 nodeId) noexcept;
     virtual void createPorts() = 0;
@@ -398,6 +405,11 @@ private:
     void prepare (double sampleRate, int blockSize, GraphProcessor*, bool willBeEnabled = false);
     void unprepare();
     void resetPorts();
+
+    int osPow = 0;
+    float osLatency = 0.0f;
+    OwnedArray<dsp::Oversampling<float>> osProcessors;
+    const int maxOsPow = 3;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (GraphNode)
 };

--- a/src/engine/GraphProcessor.cpp
+++ b/src/engine/GraphProcessor.cpp
@@ -223,6 +223,8 @@ public:
             midiBufferToUse = chans[PortType::Midi].getFirst();
 
         lastMute = node->isMuted();
+
+        node->initOversampling (totalChans, processor->getBlockSize());
     }
 
     void perform (AudioSampleBuffer& sharedBufferChans, const OwnedArray <MidiBuffer>& sharedMidiBuffers, const int numSamples)
@@ -332,14 +334,40 @@ public:
         }
         else
         {
-            if (! processor->isSuspended ())
+            auto pluginProcessBlock = [=, &sharedMidiBuffers] (AudioSampleBuffer& buffer, bool isSuspended)
             {
-                processor->processBlock (buffer, *sharedMidiBuffers.getUnchecked (midiBufferToUse));
+                if (! isSuspended)
+                {
+                    processor->processBlock (buffer, *sharedMidiBuffers.getUnchecked (midiBufferToUse));
+                }
+                else
+                {
+                    processor->processBlockBypassed (buffer, *sharedMidiBuffers.getUnchecked (midiBufferToUse));
+                }
+            };
+
+            if (node->getOversamplingFactor() > 1)
+            {
+                auto osProcessor = node->getOversamplingProcessor();
+
+                dsp::AudioBlock<float> block (buffer);
+                dsp::AudioBlock<float> osBlock = osProcessor->processSamplesUp (block);
+
+                std::unique_ptr<float*> ptrArray;
+                ptrArray.reset (new float* [buffer.getNumChannels()]);
+                for (int ch = 0; ch < buffer.getNumChannels(); ++ch)
+                    ptrArray.get()[ch] = osBlock.getChannelPointer (ch);
+
+                AudioBuffer<float> osBuffer (ptrArray.get(), buffer.getNumChannels(), static_cast<int> (osBlock.getNumSamples()));
+                pluginProcessBlock (osBuffer, processor->isSuspended());
+
+                osProcessor->processSamplesDown (block);
             }
             else
             {
-                processor->processBlockBypassed (buffer, *sharedMidiBuffers.getUnchecked (midiBufferToUse));
+                pluginProcessBlock (buffer, processor->isSuspended());
             }
+            
         }
         
         if (muted && !muteInput)
@@ -1332,7 +1360,7 @@ void GraphProcessor::prepareToPlay (double sampleRate, int estimatedSamplesPerBl
     currentMidiInputBuffer = nullptr;
     currentMidiOutputBuffer.clear();
     clearRenderingSequence();
-    
+
     if (getSampleRate() != sampleRate || getBlockSize() != estimatedSamplesPerBlock)
     {
         setPlayConfigDetails (getTotalNumInputChannels(), getTotalNumOutputChannels(),

--- a/src/gui/ContextMenus.h
+++ b/src/gui/ContextMenus.h
@@ -203,7 +203,27 @@ public:
         int index = 30000;
         GraphNodePtr ptr = node.getGraphNode();
         menu.addItem (index++, "Mute input ports", ptr != nullptr, ptr && ptr->isMutingInputs());
+
+        addOversamplingSubmenu (menu);
+
         addSubMenu ("Options", menu, ptr != nullptr);
+    }
+
+    inline void addOversamplingSubmenu (PopupMenu& menuToAddTo)
+    {
+        PopupMenu osMenu;
+        int index = 40000;
+        GraphNodePtr ptr = node.getGraphNode();
+
+        if (ptr == nullptr || ptr->isAudioIONode() || ptr->isMidiIONode()) // not the right type of node
+            return;
+
+        osMenu.addItem (index++, "1x", true, ptr->getOversamplingFactor() == 1);
+        osMenu.addItem (index++, "2x", true, ptr->getOversamplingFactor() == 2);
+        osMenu.addItem (index++, "4x", true, ptr->getOversamplingFactor() == 4);
+        osMenu.addItem (index++, "8x", true, ptr->getOversamplingFactor() == 8);
+                                                      
+        menuToAddTo.addSubMenu ("Oversample", osMenu);
     }
 
     inline void addReplaceSubmenu (PluginManager& plugins)
@@ -334,6 +354,16 @@ public:
                 case 0:
                     node.setMuteInput (! node.isMutingInputs());
                     break;
+            }
+        }
+        else if (result >= 40000 && result < 50000)
+        {
+            const int osFactor = (int) powf(2, float (result - 40000));
+            if (auto gNode = node.getGraphNode())
+            {
+                gNode->setOversamplingFactor (osFactor);
+                gNode->getParentGraph()->releaseResources();
+                gNode->getParentGraph()->prepareToPlay (gNode->getParentGraph()->getSampleRate(), gNode->getParentGraph()->getBlockSize());
             }
         }
         

--- a/tools/jucer/Element/Element.jucer
+++ b/tools/jucer/Element/Element.jucer
@@ -575,6 +575,7 @@
         <MODULEPATH id="kv_engines" path="../../../libs/kv/modules"/>
         <MODULEPATH id="kv_gui" path="../../../libs/kv/modules"/>
         <MODULEPATH id="kv_models" path="../../../libs/kv/modules"/>
+        <MODULEPATH id="juce_dsp" path="../../../libs/JUCE/modules"/>
       </MODULEPATHS>
     </XCODE_MAC>
     <VS2017 targetFolder="Builds/VisualStudio2017" windowsTargetPlatformVersion="10.0.16299.0"
@@ -626,6 +627,7 @@
         <MODULEPATH id="kv_engines" path="../../../libs/kv/modules"/>
         <MODULEPATH id="kv_gui" path="../../../libs/kv/modules"/>
         <MODULEPATH id="kv_models" path="../../../libs/kv/modules"/>
+        <MODULEPATH id="juce_dsp" path="../../../libs/JUCE/modules"/>
       </MODULEPATHS>
     </VS2017>
   </EXPORTFORMATS>
@@ -640,6 +642,7 @@
     <MODULE id="juce_core" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
     <MODULE id="juce_cryptography" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
     <MODULE id="juce_data_structures" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
+    <MODULE id="juce_dsp" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
     <MODULE id="juce_events" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
     <MODULE id="juce_graphics" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
     <MODULE id="juce_gui_basics" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>

--- a/tools/jucer/ElementFX/ElementFX.jucer
+++ b/tools/jucer/ElementFX/ElementFX.jucer
@@ -572,6 +572,7 @@
         <MODULEPATH id="kv_engines" path="../../../libs/kv/modules"/>
         <MODULEPATH id="kv_gui" path="../../../libs/kv/modules"/>
         <MODULEPATH id="kv_models" path="../../../libs/kv/modules"/>
+        <MODULEPATH id="juce_dsp" path="../../../libs/JUCE/modules"/>
       </MODULEPATHS>
     </XCODE_MAC>
     <VS2017 targetFolder="Builds/VisualStudio2017" windowsTargetPlatformVersion="10.0.16299.0"
@@ -617,6 +618,7 @@
         <MODULEPATH id="kv_engines" path="../../../libs/kv/modules"/>
         <MODULEPATH id="kv_gui" path="../../../libs/kv/modules"/>
         <MODULEPATH id="kv_models" path="../../../libs/kv/modules"/>
+        <MODULEPATH id="juce_dsp" path="../../../libs/JUCE/modules"/>
       </MODULEPATHS>
     </VS2017>
   </EXPORTFORMATS>
@@ -631,6 +633,7 @@
     <MODULE id="juce_core" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
     <MODULE id="juce_cryptography" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
     <MODULE id="juce_data_structures" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
+    <MODULE id="juce_dsp" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
     <MODULE id="juce_events" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
     <MODULE id="juce_graphics" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
     <MODULE id="juce_gui_basics" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>

--- a/tools/jucer/Standalone/Element.jucer
+++ b/tools/jucer/Standalone/Element.jucer
@@ -574,6 +574,7 @@
         <MODULEPATH id="kv_gui" path="../../../libs/kv/modules"/>
         <MODULEPATH id="kv_models" path="../../../libs/kv/modules"/>
         <MODULEPATH id="jlv2_host" path="../../../libs/jlv2/modules"/>
+        <MODULEPATH id="juce_dsp" path="../../../libs/JUCE/modules"/>
       </MODULEPATHS>
     </XCODE_MAC>
     <VS2017 targetFolder="Builds/VisualStudio2017" extraDefs="KSP1_INTERNAL=1&#10;HAVE_LVTK=1&#10;JUCE_PLUGINHOST_VST=1&#10;JUCE_PLUGINHOST_VST3=1&#10;SCL_SECURE_NO_WARNINGS=1&#10;_SCL_SECURE_NO_WARNINGS=1&#10;"
@@ -621,6 +622,7 @@
         <MODULEPATH id="kv_gui" path="../../../libs/kv/modules"/>
         <MODULEPATH id="kv_models" path="../../../libs/kv/modules"/>
         <MODULEPATH id="jlv2_host" path="../../../libs/jlv2/modules"/>
+        <MODULEPATH id="juce_dsp" path="../../../libs/JUCE/modules"/>
       </MODULEPATHS>
     </VS2017>
   </EXPORTFORMATS>
@@ -634,6 +636,7 @@
     <MODULES id="juce_core" showAllCode="1" useLocalCopy="0"/>
     <MODULES id="juce_cryptography" showAllCode="1" useLocalCopy="0"/>
     <MODULES id="juce_data_structures" showAllCode="1" useLocalCopy="0"/>
+    <MODULE id="juce_dsp" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
     <MODULES id="juce_events" showAllCode="1" useLocalCopy="0"/>
     <MODULES id="juce_graphics" showAllCode="1" useLocalCopy="0"/>
     <MODULES id="juce_gui_basics" showAllCode="1" useLocalCopy="0"/>


### PR DESCRIPTION
Fixes #17 . A few things to note:
  - Since I'm using the JUCE oversampling code, I've included the JUCE DSP module for the Projucer projects. I'm not sure how to do this for waf compilation (also looking forward to MINGW compilation with waf!)
  - Latency: Part of the nature of oversampling is that it can introduce fractional sample latency. Currently I'm rounding this latency to the nearest int, in theory we could use a fractional delay line for latency compensation in this case, but that's a larger proposition (see [here](https://forum.juce.com/t/dsp-module-discussion-new-oversampling-class/24153/6)).
  - Still finding my way around the code base, I'd love to figure more elegant solutions for a couple of the things being done here :)