### PR TITLE
Save and restore state for OSCReceiver/Sender

### DIFF
--- a/src/engine/nodes/OSCReceiverNode.cpp
+++ b/src/engine/nodes/OSCReceiverNode.cpp
@@ -152,10 +152,9 @@ bool OSCReceiverNode::connect (int portNumber)
     if (connected && currentPortNumber == portNumber)
         return connected;
 
+    currentPortNumber = portNumber;
     connected = oscReceiver.connect (portNumber);
-    if ( connected ) {
-        currentPortNumber = portNumber;
-    }
+
     return connected;
 }
 

--- a/src/engine/nodes/OSCReceiverNode.cpp
+++ b/src/engine/nodes/OSCReceiverNode.cpp
@@ -2,7 +2,7 @@
     This file is part of Element
     Copyright (C) 2019  Kushview, LLC.  All rights reserved.
     Author Eliot Akira <me@eliotakira.com>
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or

--- a/src/engine/nodes/OSCReceiverNode.h
+++ b/src/engine/nodes/OSCReceiverNode.h
@@ -27,6 +27,7 @@
 namespace Element {
 
 class OSCReceiverNode : public MidiFilterNode,
+                        public ChangeBroadcaster,
                         public OSCReceiver::Listener<OSCReceiver::RealtimeCallback>
 {
 public:
@@ -54,8 +55,8 @@ public:
     void prepareToRender (double sampleRate, int maxBufferSize) override;
     void releaseResources() override {};
     void render (AudioSampleBuffer& audio, MidiPipe& midi) override;
-    void setState (const void* data, int size) override {};
-    void getState (MemoryBlock& block) override {};
+    void setState (const void* data, int size) override;
+    void getState (MemoryBlock& block) override;
     inline void createPorts() override;
 
     /** For node editor */
@@ -69,6 +70,8 @@ public:
     bool isPaused ();
     int getCurrentPortNumber ();
     String getCurrentHostName ();
+    void setPortNumber (int port);
+    void setHostName (String hostName);
 
     void addMessageLoopListener (OSCReceiver::Listener<OSCReceiver::MessageLoopCallback>* callback);
     void removeMessageLoopListener (OSCReceiver::Listener<OSCReceiver::MessageLoopCallback>* callback);

--- a/src/engine/nodes/OSCReceiverNode.h
+++ b/src/engine/nodes/OSCReceiverNode.h
@@ -2,7 +2,7 @@
     This file is part of Element
     Copyright (C) 2019  Kushview, LLC.  All rights reserved.
     Author Eliot Akira <me@eliotakira.com>
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -85,7 +85,7 @@ private:
     OSCReceiver oscReceiver;
     bool connected = false;
     bool paused = false;
-    int currentPortNumber = -1;
+    int currentPortNumber = 9001;
     String currentHostName = "";
 
     void oscMessageReceived(const OSCMessage& message) override;

--- a/src/engine/nodes/OSCSenderNode.h
+++ b/src/engine/nodes/OSCSenderNode.h
@@ -26,7 +26,8 @@
 
 namespace Element {
 
-class OSCSenderNode : public MidiFilterNode
+class OSCSenderNode : public MidiFilterNode,
+                      public ChangeBroadcaster
 {
 public:
 
@@ -54,9 +55,8 @@ public:
     void releaseResources() override {};
 
     void render (AudioSampleBuffer& audio, MidiPipe& midi) override;
-
-    void setState (const void* data, int size) override {};
-    void getState (MemoryBlock& block) override {};
+    void setState (const void* data, int size) override;
+    void getState (MemoryBlock& block) override;
 
     inline void createPorts() override;
 
@@ -72,6 +72,8 @@ public:
 
     int getCurrentPortNumber ();
     String getCurrentHostName ();
+    void setPortNumber (int port);
+    void setHostName (String hostName);
 
     std::vector<OSCMessage> getOscMessages();
 

--- a/src/engine/nodes/OSCSenderNode.h
+++ b/src/engine/nodes/OSCSenderNode.h
@@ -2,7 +2,7 @@
     This file is part of Element
     Copyright (C) 2019  Kushview, LLC.  All rights reserved.
     Author Eliot Akira <me@eliotakira.com>
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -86,7 +86,7 @@ private:
     bool connected = false;
     bool paused = false;
 
-    int currentPortNumber = -1;
+    int currentPortNumber = 9002;
     String currentHostName = "127.0.0.1";
 
     std::vector<OSCMessage> oscMessages;

--- a/src/gui/nodes/OSCReceiverNodeEditor.cpp
+++ b/src/gui/nodes/OSCReceiverNodeEditor.cpp
@@ -59,7 +59,6 @@ OSCReceiverNodeEditor::OSCReceiverNodeEditor (const Node& node)
         String newHostName = hostNameField.getText();
         if (currentHostName == newHostName)
             return;
-DBG("hostNameField.onTextChange");
         if (connected)
             disconnect();
         currentHostName = newHostName;
@@ -70,7 +69,6 @@ DBG("hostNameField.onTextChange");
         int newPortNumber = roundToInt( portNumberSlider.getValue() );
         if (newPortNumber == currentPortNumber)
             return;
-DBG("portNumberSlider.onValueChange");
         if (connected)
             disconnect();
         currentPortNumber = newPortNumber;
@@ -238,7 +236,6 @@ void OSCReceiverNodeEditor::connect()
 
 void OSCReceiverNodeEditor::disconnect()
 {
-DBG("disconnect");
     if (oscReceiverNodePtr->disconnect())
     {
         connected = false;

--- a/src/gui/nodes/OSCReceiverNodeEditor.cpp
+++ b/src/gui/nodes/OSCReceiverNodeEditor.cpp
@@ -83,8 +83,11 @@ OSCReceiverNodeEditor::~OSCReceiverNodeEditor()
 {
     /* Unbind handlers */
     connectButton.onClick = nullptr;
+    pauseButton.onClick = nullptr;
     clearButton.onClick = nullptr;
+    hostNameField.onTextChange = nullptr;
     portNumberSlider.onValueChange = nullptr;
+    oscReceiverNodePtr->removeChangeListener (this);
     oscReceiverNodePtr->removeMessageLoopListener (this);
 }
 

--- a/src/gui/nodes/OSCReceiverNodeEditor.h
+++ b/src/gui/nodes/OSCReceiverNodeEditor.h
@@ -2,7 +2,7 @@
     This file is part of Element
     Copyright (C) 2019  Kushview, LLC.  All rights reserved.
     Author Eliot Akira <me@eliotakira.com>
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -92,7 +92,7 @@ private:
     Label hostNameLabel      { {}, "Host" };
     Label hostNameField      { {}, "127.0.0.1" };
     Label portNumberLabel    { {}, "Port" };
-    Label portNumberField    { {}, "9000" };
+    Slider portNumberSlider;
 
     TextButton connectButton { "Connect" };
     TextButton pauseButton { "Pause" };

--- a/src/gui/nodes/OSCReceiverNodeEditor.h
+++ b/src/gui/nodes/OSCReceiverNodeEditor.h
@@ -75,6 +75,7 @@ private:
 };
 
 class OSCReceiverNodeEditor : public NodeEditorComponent,
+                              public ChangeListener,
                               private OSCReceiver::Listener<OSCReceiver::MessageLoopCallback>
 {
 public:
@@ -84,6 +85,8 @@ public:
     void paint (Graphics&) override;
     void resized() override;
     void resetBounds (int width, int height);
+    void changeListenerCallback (ChangeBroadcaster*) override;
+    void syncUIFromNodeState ();
 
 private:
     OSCReceiverLogListBox oscReceiverLog;
@@ -112,6 +115,8 @@ private:
     void updateConnectButton();
     void updateConnectionStatusLabel();
     void updatePauseButton();
+    void updateHostNameField();
+    void updatePortNumberSlider();
 
     void connect();
     void disconnect();

--- a/src/gui/nodes/OSCSenderNodeEditor.cpp
+++ b/src/gui/nodes/OSCSenderNodeEditor.cpp
@@ -86,10 +86,13 @@ OSCSenderNodeEditor::OSCSenderNodeEditor (const Node& node)
 OSCSenderNodeEditor::~OSCSenderNodeEditor()
 {
     /* Unbind handlers */
-    connectButton.onClick = nullptr;
-    clearButton.onClick = nullptr;
-    portNumberSlider.onValueChange = nullptr;
     stopTimer ();
+    connectButton.onClick = nullptr;
+    pauseButton.onClick = nullptr;
+    clearButton.onClick = nullptr;
+    hostNameField.onTextChange = nullptr;
+    portNumberSlider.onValueChange = nullptr;
+    oscSenderNodePtr->removeChangeListener (this);
 }
 
 void OSCSenderNodeEditor::timerCallback() {

--- a/src/gui/nodes/OSCSenderNodeEditor.h
+++ b/src/gui/nodes/OSCSenderNodeEditor.h
@@ -75,6 +75,7 @@ private:
 };
 
 class OSCSenderNodeEditor : public NodeEditorComponent,
+                            public ChangeListener,
                             private Timer
 {
 public:
@@ -85,6 +86,8 @@ public:
     void resized() override;
     void resetBounds (int width, int height);
     void timerCallback() override;
+    void changeListenerCallback (ChangeBroadcaster*) override;
+    void syncUIFromNodeState ();
 
 private:
     OSCSenderLogListBox oscSenderLog;
@@ -115,6 +118,8 @@ private:
     void updateConnectButton();
     void updateConnectionStatusLabel();
     void updatePauseButton();
+    void updateHostNameField();
+    void updatePortNumberSlider();
 
     void connect();
     void disconnect();

--- a/src/gui/nodes/OSCSenderNodeEditor.h
+++ b/src/gui/nodes/OSCSenderNodeEditor.h
@@ -2,7 +2,7 @@
     This file is part of Element
     Copyright (C) 2019  Kushview, LLC.  All rights reserved.
     Author Eliot Akira <me@eliotakira.com>
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -94,7 +94,7 @@ private:
     Label hostNameLabel      { {}, "Host" };
     Label hostNameField      { {}, "127.0.0.1" };
     Label portNumberLabel    { {}, "Port" };
-    Label portNumberField    { {}, "9001" };
+    Slider portNumberSlider;
 
     TextButton connectButton { "Connect" };
     TextButton pauseButton { "Pause" };


### PR DESCRIPTION
Further efforts for #78.

I learned how to get/setState and sync with the UI. Now it remembers host name, port number, paused state and connection state (if saved as connected, will reconnect upon setState).

Also improved the port number slider to look like the one you added in Preferences, with inc/decrement buttons.

I wasn't sure if I could keep pushing to the `feature/osc` branch on my fork and make another pull request from it - so I made a new branch for this PR.