### PR TITLE
OSCSender: Process MIDI -> OSC in its own thread

### DIFF
--- a/src/engine/nodes/OSCReceiverNode.cpp
+++ b/src/engine/nodes/OSCReceiverNode.cpp
@@ -110,19 +110,7 @@ void OSCReceiverNode::render (AudioSampleBuffer& audio, MidiPipe& midi)
         return;
     }
 
-    auto& midiOut = *midi.getWriteBuffer (0);
-
-    MidiBuffer messages;
-    outputMidiMessages.removeNextBlockOfMessages (messages, nframes);
-
-    MidiBuffer::Iterator iter1 (messages);
-    MidiMessage msg;
-    int frame;
-
-    while (iter1.getNextEvent (msg, frame))
-    {
-        midiOut.addEvent (msg, frame);
-    }
+    outputMidiMessages.removeNextBlockOfMessages ( *midi.getWriteBuffer (0), nframes );
 }
 
 /** OSCReceiver real-time callbacks */

--- a/src/engine/nodes/OSCReceiverNode.cpp
+++ b/src/engine/nodes/OSCReceiverNode.cpp
@@ -35,8 +35,8 @@ OSCReceiverNode::OSCReceiverNode()
 
 OSCReceiverNode::~OSCReceiverNode()
 {
-   oscReceiver.removeListener (this);
-   oscReceiver.disconnect();
+    oscReceiver.removeListener (this);
+    oscReceiver.disconnect();
 }
 
 void OSCReceiverNode::setState (const void* data, int size)
@@ -95,7 +95,6 @@ inline void OSCReceiverNode::createPorts()
 
 void OSCReceiverNode::prepareToRender (double sampleRate, int maxBufferSize)
 {
-
     if (! outputMidiMessagesInitDone) {
         outputMidiMessages.reset (sampleRate);
         currentSampleRate = sampleRate;

--- a/src/engine/nodes/OSCReceiverNode.cpp
+++ b/src/engine/nodes/OSCReceiverNode.cpp
@@ -104,7 +104,6 @@ void OSCReceiverNode::prepareToRender (double sampleRate, int maxBufferSize)
 
 void OSCReceiverNode::render (AudioSampleBuffer& audio, MidiPipe& midi)
 {
-    auto timestamp = Time::getMillisecondCounterHiRes();
     const auto nframes = audio.getNumSamples();
     if (nframes == 0) {
         return;

--- a/src/engine/nodes/OSCSenderNode.cpp
+++ b/src/engine/nodes/OSCSenderNode.cpp
@@ -106,11 +106,11 @@ void OSCSenderNode::run ()
         {
             OSCMessage oscMsg = Util::processMidiToOscMessage (msg);
             oscSender.send ( oscMsg );
-
-            if (oscMessagesToLog.size() > maxOscMessages)
-                oscMessagesToLog.erase ( oscMessagesToLog.begin() );
             oscMessagesToLog.push_back ( oscMsg );
         }
+
+        while (oscMessagesToLog.size() > maxOscMessages)
+            oscMessagesToLog.erase ( oscMessagesToLog.begin() );
     }
 
     DBG("[EL] OSCSenderNode: OSC -> MIDI processing thread exited");

--- a/src/engine/nodes/OSCSenderNode.cpp
+++ b/src/engine/nodes/OSCSenderNode.cpp
@@ -246,7 +246,8 @@ void OSCSenderNode::setHostName (String hostName)
 
 std::vector<OSCMessage> OSCSenderNode::getOscMessages()
 {
-    std::vector<OSCMessage> copied = oscMessagesToLog;
+    std::vector<OSCMessage> copied;
+    std::copy ( oscMessagesToLog.begin(), oscMessagesToLog.end(), std::back_inserter( copied ) );
     oscMessagesToLog.clear();
     return copied;
 }

--- a/src/engine/nodes/OSCSenderNode.cpp
+++ b/src/engine/nodes/OSCSenderNode.cpp
@@ -150,7 +150,6 @@ void OSCSenderNode::prepareToRender (double sampleRate, int maxBufferSize) {
 
 void OSCSenderNode::render (AudioSampleBuffer& audio, MidiPipe& midi)
 {
-    auto timestamp = Time::getMillisecondCounterHiRes();
     const auto nframes = audio.getNumSamples();
     auto* const midiIn = midi.getWriteBuffer (0);
 
@@ -162,6 +161,7 @@ void OSCSenderNode::render (AudioSampleBuffer& audio, MidiPipe& midi)
     MidiBuffer::Iterator iter1 (*midiIn);
     MidiMessage msg;
     int frame;
+    auto timestamp = Time::getMillisecondCounterHiRes();
 
     while (iter1.getNextEvent (msg, frame))
     {

--- a/src/engine/nodes/OSCSenderNode.cpp
+++ b/src/engine/nodes/OSCSenderNode.cpp
@@ -100,6 +100,8 @@ void OSCSenderNode::run ()
         MidiMessage msg;
         int frame;
 
+        ScopedLock sl (lock);
+
         while (iter1.getNextEvent (msg, frame))
         {
             OSCMessage oscMsg = Util::processMidiToOscMessage (msg);
@@ -246,8 +248,11 @@ void OSCSenderNode::setHostName (String hostName)
 
 std::vector<OSCMessage> OSCSenderNode::getOscMessages()
 {
+    ScopedLock sl (lock);
+
     std::vector<OSCMessage> copied;
     std::copy ( oscMessagesToLog.begin(), oscMessagesToLog.end(), std::back_inserter( copied ) );
+
     oscMessagesToLog.clear();
     return copied;
 }

--- a/src/engine/nodes/OSCSenderNode.cpp
+++ b/src/engine/nodes/OSCSenderNode.cpp
@@ -100,18 +100,16 @@ void OSCSenderNode::run ()
         MidiMessage msg;
         int frame;
 
+        ScopedLock sl (lock);
+
         while (iter1.getNextEvent (msg, frame))
         {
             OSCMessage oscMsg = Util::processMidiToOscMessage (msg);
-            oscSender.send (oscMsg);
+            oscSender.send ( oscMsg );
 
-            {
-                ScopedLock sl (lock);
-
-                if (oscMessagesToLog.size() > maxOscMessages)
-                    oscMessagesToLog.erase ( oscMessagesToLog.begin() );
-                oscMessagesToLog.push_back ( oscMsg );
-            }
+            if (oscMessagesToLog.size() > maxOscMessages)
+                oscMessagesToLog.erase ( oscMessagesToLog.begin() );
+            oscMessagesToLog.push_back ( oscMsg );
         }
     }
 
@@ -167,7 +165,7 @@ void OSCSenderNode::render (AudioSampleBuffer& audio, MidiPipe& midi)
 
     while (iter1.getNextEvent (msg, frame))
     {
-        msg.setTimeStamp ( timestamp + frame );
+        msg.setTimeStamp ( timestamp + (1000.0 * (static_cast<double> (frame) / currentSampleRate)) );
         midiMessageQueue.addMessageToQueue ( msg );
     }
 

--- a/src/engine/nodes/OSCSenderNode.h
+++ b/src/engine/nodes/OSCSenderNode.h
@@ -26,8 +26,9 @@
 
 namespace Element {
 
-class OSCSenderNode : public MidiFilterNode,
-                      public ChangeBroadcaster
+class OSCSenderNode   : public MidiFilterNode,
+                        public ChangeBroadcaster,
+                        public Thread
 {
 public:
 
@@ -49,18 +50,23 @@ public:
         desc.version            = "1.0.0";
     }
 
+    void getState (MemoryBlock& block) override;
+    void setState (const void* data, int size) override;
+
+    /** OSC -> MIDI processing thread */
+
+    void run() override;
+    void stop();
+
     /** MIDI */
 
-    void prepareToRender (double sampleRate, int maxBufferSize) override {};
-    void releaseResources() override {};
-
+    void prepareToRender (double sampleRate, int maxBufferSize) override;
     void render (AudioSampleBuffer& audio, MidiPipe& midi) override;
-    void setState (const void* data, int size) override;
-    void getState (MemoryBlock& block) override;
+    void releaseResources() override {};
 
     inline void createPorts() override;
 
-    /** For node editor */
+    /** GUI */
 
     bool connect (String hostName, int portNumber);
     bool disconnect ();
@@ -79,6 +85,8 @@ public:
 
 private:
 
+    Semaphore sem;
+
     /** MIDI */
     bool createdPorts = false;
 
@@ -91,8 +99,18 @@ private:
     int currentPortNumber = 9002;
     String currentHostName = "127.0.0.1";
 
-    std::vector<OSCMessage> oscMessages;
+    /** Max messages in queue before they start getting dropped */
     int maxOscMessages = 100;
+
+    /** GUI */
+    std::vector<OSCMessage> oscMessagesToLog;
+
+    /** To be processed and sent as OSC messages */
+    MidiMessageCollector midiMessageQueue;
+
+    Atomic<int> numSamples = 0;
+    double currentSampleRate = 0;
+    bool midiMessageQueueInitDone = false;
 };
 
 }

--- a/src/engine/nodes/OSCSenderNode.h
+++ b/src/engine/nodes/OSCSenderNode.h
@@ -86,6 +86,7 @@ public:
 private:
 
     Semaphore sem;
+    CriticalSection lock;
 
     /** MIDI */
     bool createdPorts = false;

--- a/src/gui/nodes/OSCReceiverNodeEditor.cpp
+++ b/src/gui/nodes/OSCReceiverNodeEditor.cpp
@@ -230,6 +230,7 @@ void OSCReceiverNodeEditor::connect()
     {
         connected = true;
         connectButton.setButtonText ("Disconnect");
+        updateConnectionStatusLabel();
     }
     else
     {
@@ -243,6 +244,7 @@ void OSCReceiverNodeEditor::disconnect()
     {
         connected = false;
         connectButton.setButtonText ("Connect");
+        updateConnectionStatusLabel();
     }
     else
     {

--- a/src/gui/nodes/OSCSenderNodeEditor.cpp
+++ b/src/gui/nodes/OSCSenderNodeEditor.cpp
@@ -97,7 +97,7 @@ OSCSenderNodeEditor::~OSCSenderNodeEditor()
 
 void OSCSenderNodeEditor::timerCallback() {
 
-    const std::vector<OSCMessage>& oscMessages = oscSenderNodePtr->getOscMessages();
+    const std::vector<OSCMessage> oscMessages = oscSenderNodePtr->getOscMessages();
 
     for(auto msg : oscMessages)
     {

--- a/src/gui/nodes/OSCSenderNodeEditor.cpp
+++ b/src/gui/nodes/OSCSenderNodeEditor.cpp
@@ -96,7 +96,9 @@ OSCSenderNodeEditor::~OSCSenderNodeEditor()
 }
 
 void OSCSenderNodeEditor::timerCallback() {
-    std::vector<OSCMessage> oscMessages = oscSenderNodePtr->getOscMessages();
+
+    const std::vector<OSCMessage>& oscMessages = oscSenderNodePtr->getOscMessages();
+
     for(auto msg : oscMessages)
     {
         oscSenderLog.addOSCMessage( msg );

--- a/src/gui/nodes/OSCSenderNodeEditor.cpp
+++ b/src/gui/nodes/OSCSenderNodeEditor.cpp
@@ -232,6 +232,7 @@ void OSCSenderNodeEditor::connect()
     {
         connected = true;
         connectButton.setButtonText ("Disconnect");
+        updateConnectionStatusLabel();
     }
     else
     {
@@ -243,10 +244,9 @@ void OSCSenderNodeEditor::disconnect()
 {
     if (oscSenderNodePtr->disconnect())
     {
-        currentPortNumber = -1;
-        currentHostName = "";
         connected = false;
         connectButton.setButtonText ("Connect");
+        updateConnectionStatusLabel();
     }
     else
     {

--- a/tests/engine/osc/node-client/index.js
+++ b/tests/engine/osc/node-client/index.js
@@ -1,7 +1,7 @@
 const OSC = require('osc-js')
 
-const senderPort = 9000 // To Element: OSC Receiver node
-const receiverPort = 9001 // From Element: OSC Sender node
+const senderPort = 9001 // To Element: OSC Receiver node
+const receiverPort = 9002 // From Element: OSC Sender node
 
 const osc = new OSC({
   plugin: new OSC.DatagramPlugin({


### PR DESCRIPTION
Pushing forward on #78. I was able to use Thread and Semaphore to process MIDI -> OSC independent of the audio thread. The `ffmpeg` example was very helpful as reference.

It felt almost too easy to do this multithreading magic - could you confirm that it's done correctly?