### PR TITLE
No log for MIDI clock message

### DIFF
--- a/src/engine/nodes/MidiMonitorNode.cpp
+++ b/src/engine/nodes/MidiMonitorNode.cpp
@@ -104,6 +104,12 @@ void MidiMonitorNode::timerCallback()
     String text;
     while (iter.getNextEvent (msg, frame))
     {
+        if (msg.isMidiClock())
+        {
+            text.clear();
+            continue;
+        }
+
         if (msg.isMidiStart())
             text << "Start";
         else if (msg.isMidiStop())

--- a/src/engine/nodes/OSCSenderNode.cpp
+++ b/src/engine/nodes/OSCSenderNode.cpp
@@ -106,7 +106,11 @@ void OSCSenderNode::run ()
         {
             OSCMessage oscMsg = Util::processMidiToOscMessage (msg);
             oscSender.send ( oscMsg );
-            oscMessagesToLog.push_back ( oscMsg );
+
+            if (! msg.isMidiClock())
+            {
+                oscMessagesToLog.push_back ( oscMsg );
+            }
         }
 
         while (oscMessagesToLog.size() > maxOscMessages)


### PR DESCRIPTION
This tiny PR is for MIDI Monitor and OSC Sender to ignore MIDI clock messages in the logs, since they're so frequent.

---
By the way, thank you for commit 561adbd to add scoped lock, that made the MIDI monitor perfectly responsive!