### PR TITLE
Document MIDI commands for OSC Sender/Receiver

### DIFF
--- a/docs/osc.md
+++ b/docs/osc.md
@@ -32,8 +32,23 @@ Element can be controlled by OSC.
 | `/element/command/graphSave` | Save the current graph |
 | `/element/command/graphSaveAs` | Save the current graph as |
 
-#### OSC Sender Node
-TODO...
+#### OSC Receiver/Sender Node
 
-#### OSC Receiver Node
-TODO...
+| Command  | Values | Description   |
+|----------|--------|---------------|
+| `/midi/noteOn` | `int` channel, `int` note number, `float` velocity | Note on |
+| `/midi/noteOff` | `int` channel, `int` note number, `float` velocity | Note off |
+| `/midi/programChange` | `int` channel, `int` program number | Program change |
+| `/midi/pitchBend` | `int` channel, `int` position | Pitch bend |
+| `/midi/afterTouch` | `int` channel, `int` note number, `int` aftertouch amount | Aftertouch |
+| `/midi/channelPressure` | `int` channel, `int` pressure | Channel pressure |
+| `/midi/controlChange` | `int` channel, `int` controller type, `int`  value | Control change |
+| `/midi/allNotesOff` | `int` channel | All notes off |
+| `/midi/allSoundOff` | `int` channel | All sound off |
+| `/midi/allControllersOff` | `int` channel | All controllers off |
+| `/midi/start` | &nbsp; | Transport start |
+| `/midi/continue` | &nbsp; | Transport continue |
+| `/midi/stop` | &nbsp; | Transport stop |
+| `/midi/clock` | &nbsp; | MIDI clock |
+| `/midi/songPositionPointer` | `int` position in MIDI beats | Song position pointer |
+| `/midi/activeSense` | &nbsp; | Active sense |


### PR DESCRIPTION
I documented existing MIDI <-> OSC commands, based on `Util::processOscToMidiMessage`.

---
One command I wish it had is something like `midi/tempoChange` for OSC Sender, when Element's transport tempo is changed. It's not a real MIDI message though, so perhaps a different address is more suitable.

I had a related idea about possible message(s) to send the inital tempo and maybe time signature. There could be a "handshake" stage when an OSC Sender node is connected, Element could send inital transport state.

That would enable a setup where an external OSC client/server could "sync up". And later, when Element sends MIDI transport start/stop/continue, they can control the timing of the OSC messages to send MIDI sequences in sync with the tempo.