### PR TITLE
EQ Filter: add GUI with freq. response curve

### DIFF
--- a/src/engine/nodes/EQFilterProcessor.cpp
+++ b/src/engine/nodes/EQFilterProcessor.cpp
@@ -1,0 +1,130 @@
+/*
+Author: Jatin Chowdhury (jatin@ccrma.stanford.edu)
+
+This file is part of Element
+Copyright (C) 2019  Kushview, LLC.  All rights reserved.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+*/
+
+#include "EQFilterProcessor.h"
+#include "gui/nodes/EQFilterNodeEditor.h"
+
+namespace Element {
+
+EQFilterProcessor::EQFilterProcessor (const int _numChannels)
+    : BaseProcessor (BusesProperties()
+        .withInput ("Main", AudioChannelSet::canonicalChannelSet (jlimit (1, 2, _numChannels)))
+        .withOutput ("Main", AudioChannelSet::canonicalChannelSet (jlimit (1, 2, _numChannels)))),
+    numChannels (jlimit (1, 2, _numChannels))
+{
+    setPlayConfigDetails (numChannels, numChannels, 44100.0, 1024);
+
+    NormalisableRange<float> freqRange (20.0f, 22000.0f);
+    freqRange.setSkewForCentre (1000.0f);
+
+    NormalisableRange<float> qRange (0.1f, 18.0f);
+    qRange.setSkewForCentre (0.707f);
+
+    addParameter (freq    = new AudioParameterFloat ("freq", "Cutoff Frequency [Hz]", freqRange, 1000.0f));
+    addParameter (q       = new AudioParameterFloat ("q",    "Filter Q",              qRange,    0.707f));
+    addParameter (gainDB  = new AudioParameterFloat ("gain", "Filter Gain [dB]",      -15.0f, 15.0f, 0.0f));
+    addParameter (eqShape = new AudioParameterChoice ("shape", "EQ Shape", {"Bell", "Notch", "Hi Shelf", "Low Shelf", "HPF", "LPF"}, 0));
+}
+
+void EQFilterProcessor::fillInPluginDescription (PluginDescription &desc) const
+{
+    desc.name = getName();
+    desc.fileOrIdentifier   = EL_INTERNAL_ID_EQ_FILTER;
+    desc.descriptiveName    = "EQ Filter";
+    desc.numInputChannels   = 2;
+    desc.numOutputChannels  = 2;
+    desc.hasSharedContainer = false;
+    desc.isInstrument       = false;
+    desc.manufacturerName   = "Element";
+    desc.pluginFormatName   = "Element";
+    desc.version            = "1.0.0";
+    desc.uid                = EL_INTERNAL_UID_EQ_FILTER;
+}
+
+void EQFilterProcessor::updateParams()
+{
+    for (int ch = 0; ch < 2; ++ch)
+    {
+        eqFilter[ch].setFrequency (*freq);
+        eqFilter[ch].setQ (*q);
+        eqFilter[ch].setGain (Decibels::decibelsToGain ((float) *gainDB));
+        eqFilter[ch].setShape ((EQFilter::Shape) eqShape->getIndex());
+    }
+}
+
+void EQFilterProcessor::prepareToPlay (double sampleRate, int maximumExpectedSamplesPerBlock)
+{
+    updateParams();
+
+    for (int ch = 0; ch < 2; ++ch)
+        eqFilter[ch].reset (sampleRate);
+
+    setPlayConfigDetails (numChannels, numChannels, sampleRate, maximumExpectedSamplesPerBlock);
+}
+
+void EQFilterProcessor::processBlock (AudioBuffer<float>& buffer, MidiBuffer&)
+{
+    const int numChans = jmin (2, buffer.getNumChannels());
+    auto** output = buffer.getArrayOfWritePointers();
+
+    updateParams();
+
+    for (int c = 0; c < numChans; ++c)
+        eqFilter[c].processBlock (output[c], buffer.getNumSamples());
+}
+
+AudioProcessorEditor* EQFilterProcessor::createEditor()
+{ 
+    return new EQFilterNodeEditor (*this);
+}
+
+void EQFilterProcessor::getStateInformation (juce::MemoryBlock& destData)
+{
+    ValueTree state (Tags::state);
+    state.setProperty ("freq",   (float) *freq,   0);
+    state.setProperty ("q",      (float) *q,      0);
+    state.setProperty ("gainDB", (float) *gainDB, 0);
+    state.setProperty ("shape",  (int) eqShape->getIndex(), 0);
+    if (auto e = state.createXml())
+        AudioProcessor::copyXmlToBinary (*e, destData);
+}
+
+void EQFilterProcessor::setStateInformation (const void* data, int sizeInBytes)
+{
+    if (auto e = AudioProcessor::getXmlFromBinary (data, sizeInBytes))
+    {
+        auto state = ValueTree::fromXml (*e);
+        if (state.isValid())
+        {
+            *freq    = (float) state.getProperty ("freq",   (float) *freq);
+            *q       = (float) state.getProperty ("q",      (float) *q);
+            *gainDB  = (float) state.getProperty ("gainDB", (float) *gainDB);
+            *eqShape = (int)   state.getProperty ("shape",  (int)   *eqShape);
+        }
+    }
+}
+
+void EQFilterProcessor::numChannelsChanged()
+{
+    numChannels = getTotalNumInputChannels();
+}
+
+}

--- a/src/gui/nodes/EQFilterNodeEditor.cpp
+++ b/src/gui/nodes/EQFilterNodeEditor.cpp
@@ -1,0 +1,249 @@
+/*
+Author: Jatin Chowdhury (jatin@ccrma.stanford.edu)
+
+This file is part of Element
+Copyright (C) 2019  Kushview, LLC.  All rights reserved.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+*/
+
+#include "EQFilterNodeEditor.h"
+
+namespace Element {
+
+EQFilterNodeEditor::KnobsComponent::KnobsComponent (EQFilterProcessor& proc, std::function<void()> paramLambda)
+{
+    auto setupSlider = [=] (AudioParameterFloat* param, String suffix = {})
+    {
+        Slider* newSlider = new Slider;
+
+        // set slider style
+        addAndMakeVisible (newSlider);
+        newSlider->setTextValueSuffix (suffix);
+        newSlider->setSliderStyle (Slider::SliderStyle::RotaryHorizontalVerticalDrag);
+        newSlider->setName (param->name);
+        newSlider->setNumDecimalPlacesToDisplay (2);
+        newSlider->setTextBoxStyle (Slider::TextBoxBelow, false, 75, 18);
+        newSlider->setColour (Slider::textBoxOutlineColourId, Colours::transparentBlack);
+
+        // connect slider to parameter
+        newSlider->setRange (Range<double> ((double) param->range.getRange().getStart(), (double) param->range.getRange().getEnd()), 0.01);
+        newSlider->setSkewFactor ((double) param->range.skew);
+        newSlider->setValue ((double) *param, dontSendNotification);
+        newSlider->setDoubleClickReturnValue (true, param->convertFrom0to1
+            (dynamic_cast<AudioProcessorParameterWithID*> (param)->getDefaultValue()));
+        newSlider->onDragStart = [param] { param->beginChangeGesture(); };
+        newSlider->onDragEnd = [param] { param->endChangeGesture(); };
+        newSlider->onValueChange = [=] { 
+            param->setValueNotifyingHost (param->convertTo0to1 ((float) newSlider->getValue()));
+            paramLambda();
+        };
+
+        sliders.add (newSlider);
+    };
+
+    auto setupBox = [=] (AudioParameterChoice* param)
+    {
+        ComboBox* newBox = new ComboBox;
+
+        addAndMakeVisible (newBox);
+        newBox->setName (param->name);
+        newBox->addItemList (param->choices, 1);
+        newBox->setSelectedItemIndex ((int) *param, dontSendNotification);
+        newBox->onChange = [=] {
+            *param = newBox->getSelectedItemIndex();
+            paramLambda();
+        };
+
+        boxes.add (newBox);
+    };
+
+    const auto params = proc.getParameters();
+
+    for (auto* param : params)
+    {
+        if (auto* paramFloat = dynamic_cast<AudioParameterFloat*> (param))
+        {
+            // set up units
+            String suffix;
+            if (paramFloat->name.contains ("Hz"))
+                suffix = " Hz";
+            else if (paramFloat->name.contains ("dB"))
+                suffix = " dB";
+
+            setupSlider (paramFloat, suffix);
+        }
+
+        else if (auto* paramChoice = dynamic_cast<AudioParameterChoice*> (param))
+        {
+            setupBox (paramChoice);
+        }
+    }
+}
+
+void EQFilterNodeEditor::KnobsComponent::paint (Graphics& g)
+{
+    g.fillAll (Colours::black);
+
+    // Print names for sliders and combo boxes
+    g.setColour (Colours::white);
+    const int height = 20;
+    auto makeName = [this, &g, height] (const Component& comp, String name)
+    {
+        Rectangle<int> nameBox (comp.getX(), 2, comp.getWidth(), height);
+        g.drawFittedText (name, nameBox, Justification::centred, 1);
+    };
+
+    for (auto* s : sliders)
+        makeName (*s, s->getName().upToFirstOccurrenceOf (" [", false, false));
+
+    for (auto* b : boxes)
+        makeName (*b, b->getName());
+}
+
+void EQFilterNodeEditor::KnobsComponent::resized()
+{
+    int x = 5;
+    bool first = true;
+    for (auto* s : sliders)
+    {
+        int offset = first ? 5 : -10;
+        s->setBounds (x + offset, 20, 100, 75);
+        x = s->getRight();
+        first = false;
+    }
+
+    for (auto* b : boxes)
+    {
+        int offset = first ? 5 : 10;
+        b->setBounds (x + offset, 40, 90, 25);
+        x = b->getRight();
+        first = false;
+    }
+}
+
+//==============================================================
+EQFilterNodeEditor::FreqViz::FreqViz (EQFilterProcessor& proc)
+    : proc (proc)
+{
+    updateCurve();
+}
+
+void EQFilterNodeEditor::FreqViz::updateCurve()
+{
+    curvePath.clear();
+
+    bool started = false;
+    const float scaleFactor = (float) getHeight() / 64.0f;
+
+    // set the curve points to represent a Bode plot of the filter
+    // Reference: https://ccrma.stanford.edu/~jos/spectilt/Bode_Plots.html
+    for (float x = 0.0f; x < getWidth(); x += 0.5f)
+    {
+        auto freq = getFreqForX (x); // frequency on logarithmic axis
+        auto traceMag = Decibels::gainToDecibels (proc.getMagnitudeAtFreq (freq)); // Magnitude in Decibels
+
+        if (! started)
+        {
+            curvePath.startNewSubPath (x, getHeight() / 2 - traceMag * scaleFactor);
+            started = true;
+        }
+        else
+        {
+            curvePath.lineTo (x, getHeight() / 2 - traceMag * scaleFactor);
+        }
+    }
+
+    repaint();
+}
+
+float EQFilterNodeEditor::FreqViz::getFreqForX (float xPos)
+{
+    auto normX = xPos / (float) getWidth();
+    return lowFreq * powf (highFreq / lowFreq, normX);
+}
+
+float EQFilterNodeEditor::FreqViz::getXForFreq (float freq)
+{
+    auto normX = logf (freq / lowFreq) / logf (highFreq / lowFreq);
+    return normX * (float) getWidth();
+}
+
+void EQFilterNodeEditor::FreqViz::paint (Graphics& g)
+{
+    g.fillAll (Colours::white);
+
+    // draw freq response curve
+    g.setColour (Colours::red);
+    g.strokePath (curvePath, PathStrokeType (2.0f, PathStrokeType::JointStyle::curved));
+
+    // draw grid
+    g.setColour (Colours::grey.withAlpha (0.75f));
+    auto drawHorizontalLine = [this, &g] (float height)
+    {
+        Line<float> line (0.0f, height, (float) getWidth(), height);
+        g.drawDashedLine (line, dashLengths, 2);
+    };
+
+    auto yFrac = 6.0f;
+    for (float y = 1.0f; y < yFrac; ++y)
+        drawHorizontalLine (y * (float) getHeight() / yFrac);
+
+    float freqsToDraw[] = { 20.0f, 50.0f, 100.0f, 200.0f, 500.0f, 1000.0f, 2000.0f, 5000.0f, 10000.0f, 20000.0f };
+    auto drawVerticalLine = [this, &g] (float freq)
+    {
+        auto x = getXForFreq (freq);
+        Line<float> line (x, 0.0f, x, (float) getHeight());
+        g.drawDashedLine (line, dashLengths, 2);
+    };
+
+    for (auto freq : freqsToDraw)
+        drawVerticalLine (freq);
+}
+
+void EQFilterNodeEditor::FreqViz::resized()
+{
+    updateCurve();
+}
+
+//==============================================================
+EQFilterNodeEditor::EQFilterNodeEditor (EQFilterProcessor& proc)
+    : AudioProcessorEditor (proc),
+      proc (proc),
+      knobs (proc, [this, &proc] { proc.updateParams(); viz.updateCurve(); }),
+      viz (proc)
+{
+    addAndMakeVisible (knobs);
+    addAndMakeVisible (viz);
+
+    setSize (500, 400);
+}
+
+EQFilterNodeEditor::~EQFilterNodeEditor()
+{
+}
+
+void EQFilterNodeEditor::paint (Graphics& g)
+{
+    g.fillAll (Colours::black);
+}
+
+void EQFilterNodeEditor::resized()
+{
+    viz.setBounds (0, 0, getWidth(), getHeight() - 100);
+    knobs.setBounds (0, getHeight() - 100, getWidth(), 100);
+}
+
+}

--- a/src/gui/nodes/EQFilterNodeEditor.h
+++ b/src/gui/nodes/EQFilterNodeEditor.h
@@ -1,0 +1,79 @@
+/*
+Author: Jatin Chowdhury (jatin@ccrma.stanford.edu)
+
+This file is part of Element
+Copyright (C) 2019  Kushview, LLC.  All rights reserved.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+*/
+
+#pragma once
+
+#include "engine/nodes/EQFilterProcessor.h"
+
+namespace Element {
+
+class EQFilterNodeEditor : public AudioProcessorEditor
+{
+public:
+    EQFilterNodeEditor (EQFilterProcessor& proc);
+    ~EQFilterNodeEditor();
+
+    void paint (Graphics& g) override;
+    void resized() override;
+
+private:
+    EQFilterProcessor& proc; // reference to processor for this editor
+
+    class KnobsComponent : public Component
+    {
+    public:
+        KnobsComponent (EQFilterProcessor& proc, std::function<void()> paramLambda = {});
+        ~KnobsComponent() {}
+
+        void paint (Graphics& g) override;
+        void resized() override;
+
+    private:
+        OwnedArray<Slider> sliders;
+        OwnedArray<ComboBox> boxes;
+    };
+    KnobsComponent knobs;
+
+    class FreqViz : public Component
+    {
+    public:
+        FreqViz (EQFilterProcessor& proc);
+        ~FreqViz() {}
+
+        void updateCurve();
+        float getFreqForX (float xPos);
+        float getXForFreq (float freq);
+
+        void paint (Graphics & g) override;
+        void resized() override;
+
+    private:
+        EQFilterProcessor& proc;
+        Path curvePath; // path for frequency response curve
+
+        const float lowFreq = 10.0f;
+        const float highFreq = 22000.0f;
+        const float dashLengths[2] = {4, 1};
+    };
+    FreqViz viz;
+};
+
+}

--- a/tools/jucer/Element/Element.jucer
+++ b/tools/jucer/Element/Element.jucer
@@ -120,6 +120,8 @@
                 file="../../../src/engine/nodes/CombFilterProcessor.h"/>
           <FILE id="b6sriR" name="CompressorProcessor.h" compile="0" resource="0"
                 file="../../../src/engine/nodes/CompressorProcessor.h"/>
+          <FILE id="ZPlzuE" name="EQFilterProcessor.cpp" compile="1" resource="0"
+                file="../../../src/engine/nodes/EQFilterProcessor.cpp"/>
           <FILE id="cm0l3B" name="EQFilterProcessor.h" compile="0" resource="0"
                 file="../../../src/engine/nodes/EQFilterProcessor.h"/>
           <FILE id="jeykx9" name="FreqSplitterProcessor.h" compile="0" resource="0"
@@ -221,6 +223,10 @@
                 file="../../../src/gui/nodes/AudioRouterEditor.cpp"/>
           <FILE id="abgn4X" name="AudioRouterEditor.h" compile="0" resource="0"
                 file="../../../src/gui/nodes/AudioRouterEditor.h"/>
+          <FILE id="u19H9U" name="EQFilterNodeEditor.cpp" compile="1" resource="0"
+                file="../../../src/gui/nodes/EQFilterNodeEditor.cpp"/>
+          <FILE id="V2rjXJ" name="EQFilterNodeEditor.h" compile="0" resource="0"
+                file="../../../src/gui/nodes/EQFilterNodeEditor.h"/>
           <FILE id="cj3LWs" name="GenericNodeEditor.cpp" compile="1" resource="0"
                 file="../../../src/gui/nodes/GenericNodeEditor.cpp"/>
           <FILE id="D7sKYL" name="GenericNodeEditor.h" compile="0" resource="0"

--- a/tools/jucer/ElementFX/ElementFX.jucer
+++ b/tools/jucer/ElementFX/ElementFX.jucer
@@ -119,6 +119,8 @@
                 file="../../../src/engine/nodes/CombFilterProcessor.h"/>
           <FILE id="gGyXoe" name="CompressorProcessor.h" compile="0" resource="0"
                 file="../../../src/engine/nodes/CompressorProcessor.h"/>
+          <FILE id="ZPlzuE" name="EQFilterProcessor.cpp" compile="1" resource="0"
+                file="../../../src/engine/nodes/EQFilterProcessor.cpp"/>
           <FILE id="f4mHqx" name="EQFilterProcessor.h" compile="0" resource="0"
                 file="../../../src/engine/nodes/EQFilterProcessor.h"/>
           <FILE id="vOHPX0" name="FreqSplitterProcessor.h" compile="0" resource="0"
@@ -220,6 +222,10 @@
                 file="../../../src/gui/nodes/AudioRouterEditor.cpp"/>
           <FILE id="vtZ5le" name="AudioRouterEditor.h" compile="0" resource="0"
                 file="../../../src/gui/nodes/AudioRouterEditor.h"/>
+          <FILE id="u19H9U" name="EQFilterNodeEditor.cpp" compile="1" resource="0"
+                file="../../../src/gui/nodes/EQFilterNodeEditor.cpp"/>
+          <FILE id="V2rjXJ" name="EQFilterNodeEditor.h" compile="0" resource="0"
+                file="../../../src/gui/nodes/EQFilterNodeEditor.h"/>
           <FILE id="KBhcW2" name="GenericNodeEditor.cpp" compile="1" resource="0"
                 file="../../../src/gui/nodes/GenericNodeEditor.cpp"/>
           <FILE id="rBLbMG" name="GenericNodeEditor.h" compile="0" resource="0"

--- a/tools/jucer/Standalone/Element.jucer
+++ b/tools/jucer/Standalone/Element.jucer
@@ -114,6 +114,8 @@
                 file="../../../src/engine/nodes/CombFilterProcessor.h"/>
           <FILE id="J3zknI" name="CompressorProcessor.h" compile="0" resource="0"
                 file="../../../src/engine/nodes/CompressorProcessor.h"/>
+          <FILE id="ZPlzuE" name="EQFilterProcessor.cpp" compile="1" resource="0"
+                file="../../../src/engine/nodes/EQFilterProcessor.cpp"/>
           <FILE id="vtlWJm" name="EQFilterProcessor.h" compile="0" resource="0"
                 file="../../../src/engine/nodes/EQFilterProcessor.h"/>
           <FILE id="r9qx5g" name="FreqSplitterProcessor.h" compile="0" resource="0"
@@ -215,6 +217,10 @@
                 file="../../../src/gui/nodes/AudioRouterEditor.cpp"/>
           <FILE id="OcEL8i" name="AudioRouterEditor.h" compile="0" resource="0"
                 file="../../../src/gui/nodes/AudioRouterEditor.h"/>
+          <FILE id="u19H9U" name="EQFilterNodeEditor.cpp" compile="1" resource="0"
+                file="../../../src/gui/nodes/EQFilterNodeEditor.cpp"/>
+          <FILE id="V2rjXJ" name="EQFilterNodeEditor.h" compile="0" resource="0"
+                file="../../../src/gui/nodes/EQFilterNodeEditor.h"/>
           <FILE id="kJU8oK" name="GenericNodeEditor.cpp" compile="1" resource="0"
                 file="../../../src/gui/nodes/GenericNodeEditor.cpp"/>
           <FILE id="EquLyr" name="GenericNodeEditor.h" compile="0" resource="0"


### PR DESCRIPTION
Added an editor for the EQ Filter, including a visualizer of the frequency response curve. It looks like this:
![EQFilt_Screenshot](https://user-images.githubusercontent.com/13724188/70733210-1d11d900-1cc7-11ea-971a-0352cdbe2ea1.png)

I'm not much of a designer, so I'd be happy to take suggestions to help make it look a little better.

Side note: when building from Visual Studio, I had to include the ["/bigobj" command line argument](https://docs.microsoft.com/en-us/cpp/build/reference/bigobj-increase-number-of-sections-in-dot-obj-file?view=vs-2019), otherwise I got a crpytic error related to `LuaNode.cpp`. Not sure if that's just something to do with my Visual Studio  settings?