### PR TITLE
Add sidechain processing for compressor, refactor FreqSplitter to use busses

### DIFF
--- a/src/engine/nodes/CompressorProcessor.cpp
+++ b/src/engine/nodes/CompressorProcessor.cpp
@@ -25,10 +25,12 @@ namespace Element {
 CompressorProcessor::CompressorProcessor (const int _numChannels)
     : BaseProcessor (BusesProperties()
         .withInput ("Main", AudioChannelSet::canonicalChannelSet (jlimit (1, 2, _numChannels)))
+        .withInput ("Sidechain", AudioChannelSet::canonicalChannelSet (jlimit (1, 2, _numChannels)))
         .withOutput ("Main", AudioChannelSet::canonicalChannelSet (jlimit (1, 2, _numChannels)))),
     numChannels (jlimit (1, 2, _numChannels))
 {
-    setPlayConfigDetails (numChannels, numChannels, 44100.0, 1024);
+    setBusesLayout (getBusesLayout());
+    setRateAndBufferSizeDetails (44100.0, 1024);
 
     NormalisableRange<float> ratioRange (0.5f, 10.0f);
     ratioRange.setSkewForCentre (2.0f);
@@ -39,12 +41,13 @@ CompressorProcessor::CompressorProcessor (const int _numChannels)
     NormalisableRange<float> releaseRange (10.0f, 3000.0f);
     releaseRange.setSkewForCentre (100.0f);
 
-    addParameter (threshDB  = new AudioParameterFloat ("thresh",  "Threshold [dB]", -30.0f, 0.0f, 0.0f));
-    addParameter (ratio     = new AudioParameterFloat ("ratio",   "Ratio",          ratioRange, 1.0f));
-    addParameter (kneeDB    = new AudioParameterFloat ("knee",    "Knee [dB]",      0.0f, 12.0f, 6.0f));
-    addParameter (attackMs  = new AudioParameterFloat ("attack",  "Attack [ms]",    attackRange, 10.0f));
-    addParameter (releaseMs = new AudioParameterFloat ("release", "Release [ms]",   releaseRange, 100.0f));
-    addParameter (makeupDB  = new AudioParameterFloat ("makeup",  "Makeup [dB]",    -18.0f, 18.0f, 0.0f));
+    addParameter (threshDB  = new AudioParameterFloat ("thresh",    "Threshold [dB]", -30.0f, 0.0f, 0.0f));
+    addParameter (ratio     = new AudioParameterFloat ("ratio",     "Ratio",          ratioRange, 1.0f));
+    addParameter (kneeDB    = new AudioParameterFloat ("knee",      "Knee [dB]",      0.0f, 12.0f, 6.0f));
+    addParameter (attackMs  = new AudioParameterFloat ("attack",    "Attack [ms]",    attackRange, 10.0f));
+    addParameter (releaseMs = new AudioParameterFloat ("release",   "Release [ms]",   releaseRange, 100.0f));
+    addParameter (makeupDB  = new AudioParameterFloat ("makeup",    "Makeup [dB]",    -18.0f, 18.0f, 0.0f));
+    addParameter (sideChain = new AudioParameterFloat ("sidechain", "Side Chain",     0.0f, 1.0f, 0.0f));
 
     makeupGain.reset (numSteps);
 }
@@ -54,8 +57,8 @@ void CompressorProcessor::fillInPluginDescription (PluginDescription& desc) cons
     desc.name = getName();
     desc.fileOrIdentifier   = EL_INTERNAL_ID_COMPRESSOR;
     desc.descriptiveName    = "Compressor";
-    desc.numInputChannels   = 2;
-    desc.numOutputChannels  = 2;
+    desc.numInputChannels   = numChannels * 2;
+    desc.numOutputChannels  = numChannels;
     desc.hasSharedContainer = false;
     desc.isInstrument       = false;
     desc.manufacturerName   = "Element";
@@ -68,6 +71,10 @@ void CompressorProcessor::updateParams()
 {
     detector.setAttackMs (*attackMs);
     detector.setReleaseMs (*releaseMs);
+
+    sideDetector.setAttackMs (*attackMs);
+    sideDetector.setReleaseMs (*releaseMs);
+
     gainComputer.setThreshold (*threshDB);
     gainComputer.setRatio (*ratio);
     gainComputer.setKnee (*kneeDB);
@@ -78,34 +85,40 @@ void CompressorProcessor::updateParams()
 void CompressorProcessor::prepareToPlay (double sampleRate, int maximumExpectedSamplesPerBlock)
 {
     detector.reset ((float) sampleRate);
+    sideDetector.reset ((float) sampleRate);
     gainComputer.reset();
 
-    setPlayConfigDetails (numChannels, numChannels, sampleRate, maximumExpectedSamplesPerBlock);
+    setBusesLayout (getBusesLayout());
+    setRateAndBufferSizeDetails (sampleRate, maximumExpectedSamplesPerBlock);
 }
 
 void CompressorProcessor::releaseResources() {}
 
 void CompressorProcessor::processBlock (AudioBuffer<float>& buffer, MidiBuffer&)
 {
-    auto numBuffChannels = buffer.getNumChannels();
+    auto mainBuffer = getBusBuffer (buffer, true, 0);
+    auto sideBuffer = getBusBuffer (buffer, true, 1);
+
+    auto numBuffChannels = mainBuffer.getNumChannels();
 
     updateParams();
 
     float level = 0.0f;
     for (int n = 0; n < buffer.getNumSamples(); ++n)
     {
-        // Sum input from channels
-        float detectorInput = 0.0f;
-        for (int ch = 0; ch < numBuffChannels; ++ch)
-            detectorInput += buffer.getSample (ch, n);
-        detectorInput /= (float) numBuffChannels;
+        // Get Main mono input
+        float mainInput = getSummedMonoSample (mainBuffer, n, numBuffChannels);
+
+        // Get sidechain mono input
+        float sideInput = getSummedMonoSample (sideBuffer, n, numBuffChannels);
 
         // Get level estimate, and compute gain
-        level = detector.process (detectorInput);
+        level = detector.process (mainInput) * (1.0f - *sideChain)
+              + sideDetector.process (sideInput) * *sideChain;
         float gain = gainComputer.process (level);
 
         // Apply gain
-        buffer.applyGain (n, 1, gain * makeupGain.getNextValue());
+        mainBuffer.applyGain (n, 1, gain * makeupGain.getNextValue());
     }
 
     listeners.call (&Listener::updateInGainDB, Decibels::gainToDecibels (level));
@@ -123,12 +136,13 @@ AudioProcessorEditor* CompressorProcessor::createEditor() { return new Compresso
 void CompressorProcessor::getStateInformation (juce::MemoryBlock& destData)
 {
     ValueTree state (Tags::state);
-    state.setProperty ("thresh",  (float) *threshDB,  0);
-    state.setProperty ("ratio",   (float) *ratio,     0);
-    state.setProperty ("knee",    (float) *kneeDB,    0);
-    state.setProperty ("attack",  (float) *attackMs,  0);
-    state.setProperty ("release", (float) *releaseMs, 0);
-    state.setProperty ("makeup",  (float) *makeupDB,  0);
+    state.setProperty ("thresh",    (float) *threshDB,  0);
+    state.setProperty ("ratio",     (float) *ratio,     0);
+    state.setProperty ("knee",      (float) *kneeDB,    0);
+    state.setProperty ("attack",    (float) *attackMs,  0);
+    state.setProperty ("release",   (float) *releaseMs, 0);
+    state.setProperty ("makeup",    (float) *makeupDB,  0);
+    state.setProperty ("sidechain", (float) *sideChain, 0);
     if (auto e = state.createXml())
         AudioProcessor::copyXmlToBinary (*e, destData);
 }
@@ -140,12 +154,13 @@ void CompressorProcessor::setStateInformation (const void* data, int sizeInBytes
         auto state = ValueTree::fromXml (*e);
         if (state.isValid())
         {
-            *threshDB  = (float) state.getProperty ("thresh",  (float) *threshDB);
-            *ratio     = (float) state.getProperty ("ratio",   (float) *ratio);
-            *kneeDB    = (float) state.getProperty ("knee",    (float) *kneeDB);
-            *attackMs  = (float) state.getProperty ("attack",  (float) *attackMs);
-            *releaseMs = (float) state.getProperty ("release", (float) *releaseMs);
-            *makeupDB  = (float) state.getProperty ("makeup",  (float) *makeupDB);
+            *threshDB  = (float) state.getProperty ("thresh",    (float) *threshDB);
+            *ratio     = (float) state.getProperty ("ratio",     (float) *ratio);
+            *kneeDB    = (float) state.getProperty ("knee",      (float) *kneeDB);
+            *attackMs  = (float) state.getProperty ("attack",    (float) *attackMs);
+            *releaseMs = (float) state.getProperty ("release",   (float) *releaseMs);
+            *makeupDB  = (float) state.getProperty ("makeup",    (float) *makeupDB);
+            *sideChain = (float) state.getProperty ("sidechain", (float) *sideChain);
         }
     }
 }

--- a/src/gui/nodes/CompressorNodeEditor.cpp
+++ b/src/gui/nodes/CompressorNodeEditor.cpp
@@ -125,7 +125,7 @@ CompressorNodeEditor::CompressorNodeEditor (CompressorProcessor& proc) :
     knobs (proc, [this, &proc] { proc.updateParams(); compViz.updateCurve(); }),
     compViz (proc)
 {
-    setSize (550, 420);
+    setSize (610, 420);
 
     addAndMakeVisible (knobs);
     addAndMakeVisible (compViz);

--- a/src/gui/nodes/KnobsComponent.cpp
+++ b/src/gui/nodes/KnobsComponent.cpp
@@ -122,7 +122,7 @@ void KnobsComponent::resized()
     bool first = true;
     for (auto* s : sliders)
     {
-        int offset = first ? -5 : -10;
+        int offset = first ? -3 : -15;
         s->setBounds (x + offset, 20, 100, 75);
         x = s->getRight();
         first = false;
@@ -130,7 +130,7 @@ void KnobsComponent::resized()
 
     for (auto* b : boxes)
     {
-        int offset = first ? 5 : 10;
+        int offset = first ? 5 : 0;
         b->setBounds (x + offset, 40, 90, 25);
         x = b->getRight();
         first = false;


### PR DESCRIPTION
Basic [sidechain](https://www.sageaudio.com/blog/pre-mastering-tips/sidechaining.php) for the internal compressor. Includes a knob in the GUI to allow the user to choose the mix of sidechain vs normal input to use for the compressor level detection.

Also refactored the FreqSplitter node to use busses, instead of a single buffer with a bunch of hardcoded channel numbers.

(I'm not very good at this but I'm trying to make a video to show how the sidechain can be useful for the compressor. Any assistance with this would be fantastic!)