### PR TITLE
added aumfx build to jucer files, also had to make a few other change…

### DIFF
--- a/tools/jucer/Element/Element.jucer
+++ b/tools/jucer/Element/Element.jucer
@@ -5,20 +5,19 @@
               bundleIdentifier="net.kushview.plugins.Element" includeBinaryInAppConfig="1"
               cppLanguageStandard="17" companyCopyright="Copyright (c) 2017-2019 Kushview, LLC"
               buildVST="1" buildVST3="1" buildAU="1" buildAUv3="0" buildRTAS="0"
-              buildAAX="1" buildStandalone="1" enableIAA="0" pluginName="Element"
+              buildAAX="0" buildStandalone="0" enableIAA="0" pluginName="Element"
               pluginDesc="Element Modular Instrument" pluginManufacturer="Kushview"
               pluginManufacturerCode="KshV" pluginCode="Elmt" pluginChannelConfigs=""
               pluginIsSynth="1" pluginWantsMidiIn="1" pluginProducesMidiOut="1"
               pluginIsMidiEffectPlugin="0" pluginEditorRequiresKeys="0" pluginAUExportPrefix="ElementAU"
               pluginRTASCategory="2048" aaxIdentifier="net.kushview.Element"
-              pluginAAXCategory="2048" jucerVersion="5.4.5" companyName="Kushview"
+              pluginAAXCategory="2048" jucerVersion="5.4.7" companyName="Kushview"
               companyWebsite="https://kushview.net" companyEmail="support@kushview.net"
               defines="EL_RUNNING_AS_PLUGIN=1&#10;EL_VERSION_STRING=&quot;0.41.1&quot;&#10;EL_USE_LUA=1"
               pluginVSTCategory="kPlugCategSynth" pluginAUMainType="'aumu'"
               userNotes="This configuration is for the Instrument version.  &#10;IMPORTANT: ElementFX configs are overridden in ElementFXConfig.h not this project file"
-              pluginFormats="buildVST,buildVST3,buildAU,buildAAX,buildStandalone"
-              pluginCharacteristicsValue="pluginIsSynth,pluginWantsMidiIn,pluginProducesMidiOut"
-              headerPath="../../../../../src&#10;../../../../../libs/lua&#10;../../../../../libs/lua/src&#10;../../../../../libs/lua-kv/src">
+              pluginFormats="buildAU,buildVST,buildVST3" pluginCharacteristicsValue="pluginIsSynth,pluginWantsMidiIn,pluginProducesMidiOut"
+              headerPath="../../../../../src&#10;../../../../../libs/lua&#10;../../../../../libs/lua/src&#10;../../../../../libs/lua-kv/src&#10;../../../../../build/include">
   <MAINGROUP id="SKUipM" name="Element">
     <GROUP id="{B9B38E28-65D9-4832-6C01-CBF57DBDA57B}" name="lua-kv">
       <GROUP id="{62C1DB42-24AC-1BEF-C5A1-87EE68F8EAE4}" name="src">
@@ -645,14 +644,13 @@
                extraCompilerFlags="-Wno-deprecated-declarations">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" enablePluginBinaryCopyStep="1" isDebug="1" optimisation="1"
-                       linkTimeOptimisation="0" targetName="KV_Element" headerPath="/opt/kushview/include&#10;"
+                       linkTimeOptimisation="0" targetName="KV_Element" headerPath="/opt/kushview/include&#10;/usr/local/include&#10;"
                        osxCompatibility="10.8 SDK" osxArchitecture="64BitIntel" cppLibType="libc++"
                        aaxBinaryLocation="$(HOME)/Library/Audio/Plug-Ins/AAX_unsigned"
-                       customXcodeFlags="REZ_SEARCH_PATHS=$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AudioUnit.framework/Headers"
-                       auBinaryLocation="/Library/Application Support"/>
+                       customXcodeFlags="REZ_SEARCH_PATHS=$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AudioUnit.framework/Headers"/>
         <CONFIGURATION name="Release" enablePluginBinaryCopyStep="1" isDebug="0" optimisation="3"
                        linkTimeOptimisation="1" targetName="KV_Element" cppLibType="libc++"
-                       osxArchitecture="64BitIntel" osxCompatibility="10.8 SDK" headerPath="/opt/kushview/include&#10;"
+                       osxArchitecture="64BitIntel" osxCompatibility="10.8 SDK" headerPath="/opt/kushview/include&#10;/usr/local/include"
                        aaxBinaryLocation="$(HOME)/Library/Audio/Plug-Ins/AAX_unsigned"
                        customXcodeFlags="REZ_SEARCH_PATHS=$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AudioUnit.framework/Headers,ONLY_ACTIVE_ARCH=YES,MACOSX_DEPLOYMENT_TARGET=10.8,OTHER_CODE_SIGN_FLAGS=--timestamp,CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO"/>
       </CONFIGURATIONS>

--- a/tools/jucer/ElementMFX/ElementMFX.jucer
+++ b/tools/jucer/ElementMFX/ElementMFX.jucer
@@ -1,23 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<JUCERPROJECT id="pjYkKA" name="Element FX" displaySplashScreen="0" reportAppUsage="0"
+<JUCERPROJECT id="pjYkKA" name="Element MFX" displaySplashScreen="0" reportAppUsage="0"
               splashScreenColour="Dark" projectType="audioplug" version="1.44.0"
-              bundleIdentifier="net.kushview.plugins.ElementFX" includeBinaryInAppConfig="1"
+              bundleIdentifier="net.kushview.plugins.ElementMFX" includeBinaryInAppConfig="1"
               cppLanguageStandard="17" companyCopyright="Copyright (c) 2017-2019 Kushview, LLC"
-              buildVST="1" buildVST3="1" buildAU="1" buildAUv3="0" buildRTAS="0"
-              buildAAX="0" buildStandalone="0" enableIAA="0" pluginName="Element FX"
+              buildVST="0" buildVST3="0" buildAU="1" buildAUv3="0" buildRTAS="0"
+              buildAAX="0" buildStandalone="0" enableIAA="0" pluginName="Element MFX"
               pluginDesc="Element Modular Effects Rack" pluginManufacturer="Kushview"
-              pluginManufacturerCode="KshV" pluginCode="ElFX" pluginChannelConfigs=""
+              pluginManufacturerCode="KshV" pluginCode="ElMX" pluginChannelConfigs=""
               pluginIsSynth="0" pluginWantsMidiIn="1" pluginProducesMidiOut="1"
-              pluginIsMidiEffectPlugin="0" pluginEditorRequiresKeys="0" pluginAUExportPrefix="ElementFX"
-              aaxIdentifier="net.kushview.ElementFX" jucerVersion="5.4.7" companyName="Kushview"
-              companyWebsite="https://kushview.net" companyEmail="support@kushview.net"
-              defines="EL_RUNNING_AS_PLUGIN=1&#10;EL_VERSION_STRING=&quot;0.41.1&quot;&#10;EL_USE_LUA=1"
-              pluginVSTCategory="kPlugCategEffect" pluginAUMainType="'aumf'"
+              pluginIsMidiEffectPlugin="1" pluginEditorRequiresKeys="0" pluginAUExportPrefix="ElementMFX"
+              aaxIdentifier="net.kushview.ElementMFX" jucerVersion="5.4.7"
+              companyName="Kushview" companyWebsite="https://kushview.net"
+              companyEmail="support@kushview.net" defines="EL_RUNNING_AS_PLUGIN=1&#10;EL_VERSION_STRING=&quot;0.41.1&quot;&#10;EL_USE_LUA=1"
+              pluginVSTCategory="kPlugCategEffect" pluginAUMainType="'aumi'"
               userNotes="This configuration is for the Instrument version.  &#10;IMPORTANT: ElementFX configs are overridden in ElementFXConfig.h not this project file"
-              pluginFormats="buildAU,buildVST,buildVST3" pluginCharacteristicsValue="pluginWantsMidiIn,pluginProducesMidiOut"
-              pluginAAXCategory="8192" headerPath="../../../../../src&#10;../../../../../libs/lua&#10;../../../../../libs/lua/src&#10;../../../../../libs/lua-kv/src&#10;../../../../../build/include">
-  <MAINGROUP id="SKUipM" name="Element FX">
+              pluginFormats="buildAU" pluginCharacteristicsValue="pluginWantsMidiIn,pluginProducesMidiOut,pluginIsMidiEffectPlugin"
+              pluginAAXCategory="8192" headerPath="../../../../../src&#10;../../../../../libs/lua&#10;../../../../../libs/lua/src&#10;../../../../../libs/lua-kv/src&#10;../../../../../build/include"
+              pluginRTASDisableBypass="0" pluginRTASDisableMultiMono="0" pluginAAXDisableBypass="0"
+              pluginAAXDisableMultiMono="0">
+  <MAINGROUP id="SKUipM" name="Element MFX">
     <GROUP id="{9C95AAF2-091D-90F2-8252-0716A4C35CDF}" name="libs">
       <GROUP id="{B9B38E28-65D9-4832-6C01-CBF57DBDA57B}" name="lua-kv">
         <GROUP id="{62C1DB42-24AC-1BEF-C5A1-87EE68F8EAE4}" name="src">
@@ -645,12 +647,12 @@
                prebuildCommand="export MACOSX_DEPLOYMENT_TARGET=10.8&#10;cd ../../../../.. &amp;&amp; python tools/gitversion.py&#10;">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" enablePluginBinaryCopyStep="1" isDebug="1" optimisation="1"
-                       linkTimeOptimisation="0" targetName="KV_ElementFX" headerPath="/opt/kushview/include&#10;/usr/local/include"
+                       linkTimeOptimisation="0" targetName="KV_ElementMFX" headerPath="/opt/kushview/include&#10;/usr/local/include"
                        osxCompatibility="10.8 SDK" osxArchitecture="64BitIntel" cppLibType="libc++"
                        aaxBinaryLocation="$(HOME)/Library/Audio/Plug-Ins/AAX_unsigned"
                        customXcodeFlags="REZ_SEARCH_PATHS=$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AudioUnit.framework/Headers"/>
         <CONFIGURATION name="Release" enablePluginBinaryCopyStep="1" isDebug="0" optimisation="3"
-                       linkTimeOptimisation="1" targetName="KV_ElementFX" aaxBinaryLocation="$(HOME)/Library/Audio/Plug-Ins/AAX_unsigned"
+                       linkTimeOptimisation="1" targetName="KV_ElementMFX" aaxBinaryLocation="$(HOME)/Library/Audio/Plug-Ins/AAX_unsigned"
                        codeSigningIdentity="9511F5241B78B0D38961CD756873066A5F0ED225"
                        cppLibType="libc++" osxArchitecture="64BitIntel" osxCompatibility="10.8 SDK"
                        headerPath="/opt/kushview/include&#10;/usr/local/include" customXcodeFlags="REZ_SEARCH_PATHS=$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AudioUnit.framework/Headers,ONLY_ACTIVE_ARCH=YES,MACOSX_DEPLOYMENT_TARGET=10.8,OTHER_CODE_SIGN_FLAGS=--timestamp,CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO"/>
@@ -684,22 +686,22 @@
       <CONFIGURATIONS>
         <CONFIGURATION name="Release" winWarningLevel="4" generateManifest="1" winArchitecture="x64"
                        debugInformationFormat="ProgramDatabase" enablePluginBinaryCopyStep="0"
-                       linkTimeOptimisation="1" isDebug="0" optimisation="3" targetName="KV_ElementFX"
+                       linkTimeOptimisation="1" isDebug="0" optimisation="3" targetName="KV_ElementMFX"
                        headerPath="C:\SDKs\boost_1_71_0&#10;C:\SDKs\ASIOSDK2.3\common"
                        binaryPath="../../../build/x64/Release" useRuntimeLibDLL="0"/>
         <CONFIGURATION name="Debug" winWarningLevel="2" generateManifest="1" winArchitecture="Win32"
                        debugInformationFormat="ProgramDatabase" enablePluginBinaryCopyStep="0"
-                       linkTimeOptimisation="0" isDebug="1" optimisation="1" targetName="KV_ElementFX"
+                       linkTimeOptimisation="0" isDebug="1" optimisation="1" targetName="KV_ElementMFX"
                        binaryPath="../../../build/Win32/Debug" headerPath="C:\SDKs\boost_1_71_0&#10;C:\SDKs\ASIOSDK2.3\common"
                        useRuntimeLibDLL="1"/>
         <CONFIGURATION name="Release" winWarningLevel="4" generateManifest="1" winArchitecture="Win32"
                        debugInformationFormat="ProgramDatabase" enablePluginBinaryCopyStep="0"
-                       linkTimeOptimisation="1" isDebug="0" optimisation="3" targetName="KV_ElementFX"
+                       linkTimeOptimisation="1" isDebug="0" optimisation="3" targetName="KV_ElementMFX"
                        headerPath="C:\SDKs\boost_1_71_0&#10;C:\SDKs\ASIOSDK2.3\common"
                        binaryPath="../../../build/Win32/Release" useRuntimeLibDLL="0"/>
         <CONFIGURATION name="Debug" winWarningLevel="2" generateManifest="1" winArchitecture="x64"
                        debugInformationFormat="ProgramDatabase" enablePluginBinaryCopyStep="0"
-                       linkTimeOptimisation="0" isDebug="1" optimisation="1" targetName="KV_ElementFX"
+                       linkTimeOptimisation="0" isDebug="1" optimisation="1" targetName="KV_ElementMFX"
                        binaryPath="../../../build/x64/Debug" headerPath="C:\SDKs\boost_1_71_0&#10;C:\SDKs\ASIOSDK2.3\common"
                        useRuntimeLibDLL="1"/>
       </CONFIGURATIONS>

--- a/tools/jucer/ElementMFX/JuceLibraryCode/AppConfig.h
+++ b/tools/jucer/ElementMFX/JuceLibraryCode/AppConfig.h
@@ -1,0 +1,500 @@
+/*
+
+    IMPORTANT! This file is auto-generated each time you save your
+    project - if you alter its contents, your changes may be overwritten!
+
+    There's a section below where you can add your own custom code safely, and the
+    Projucer will preserve the contents of that block, but the best way to change
+    any of these definitions is by using the Projucer's project settings.
+
+    Any commented-out settings will assume their default values.
+
+*/
+
+#pragma once
+
+//==============================================================================
+// [BEGIN_USER_CODE_SECTION]
+
+#include "CommonConfig.h"
+
+// [END_USER_CODE_SECTION]
+
+/*
+  ==============================================================================
+
+   In accordance with the terms of the JUCE 5 End-Use License Agreement, the
+   JUCE Code in SECTION A cannot be removed, changed or otherwise rendered
+   ineffective unless you have a JUCE Indie or Pro license, or are using JUCE
+   under the GPL v3 license.
+
+   End User License Agreement: www.juce.com/juce-5-licence
+
+  ==============================================================================
+*/
+
+// BEGIN SECTION A
+
+#ifndef JUCE_DISPLAY_SPLASH_SCREEN
+ #define JUCE_DISPLAY_SPLASH_SCREEN 0
+#endif
+
+#ifndef JUCE_REPORT_APP_USAGE
+ #define JUCE_REPORT_APP_USAGE 0
+#endif
+
+// END SECTION A
+
+#define JUCE_USE_DARK_SPLASH_SCREEN 1
+
+#define JUCE_PROJUCER_VERSION 0x50407
+
+//==============================================================================
+#define JUCE_MODULE_AVAILABLE_juce_audio_basics             1
+#define JUCE_MODULE_AVAILABLE_juce_audio_devices            1
+#define JUCE_MODULE_AVAILABLE_juce_audio_formats            1
+#define JUCE_MODULE_AVAILABLE_juce_audio_plugin_client      1
+#define JUCE_MODULE_AVAILABLE_juce_audio_processors         1
+#define JUCE_MODULE_AVAILABLE_juce_audio_utils              1
+#define JUCE_MODULE_AVAILABLE_juce_core                     1
+#define JUCE_MODULE_AVAILABLE_juce_cryptography             1
+#define JUCE_MODULE_AVAILABLE_juce_data_structures          1
+#define JUCE_MODULE_AVAILABLE_juce_dsp                      1
+#define JUCE_MODULE_AVAILABLE_juce_events                   1
+#define JUCE_MODULE_AVAILABLE_juce_graphics                 1
+#define JUCE_MODULE_AVAILABLE_juce_gui_basics               1
+#define JUCE_MODULE_AVAILABLE_juce_gui_extra                1
+#define JUCE_MODULE_AVAILABLE_juce_osc                      1
+#define JUCE_MODULE_AVAILABLE_kv_core                       1
+#define JUCE_MODULE_AVAILABLE_kv_engines                    1
+#define JUCE_MODULE_AVAILABLE_kv_gui                        1
+#define JUCE_MODULE_AVAILABLE_kv_models                     1
+
+#define JUCE_GLOBAL_MODULE_SETTINGS_INCLUDED 1
+
+//==============================================================================
+// juce_audio_devices flags:
+
+#ifndef    JUCE_USE_WINRT_MIDI
+ //#define JUCE_USE_WINRT_MIDI 0
+#endif
+
+#ifndef    JUCE_ASIO
+ //#define JUCE_ASIO 0
+#endif
+
+#ifndef    JUCE_WASAPI
+ //#define JUCE_WASAPI 1
+#endif
+
+#ifndef    JUCE_WASAPI_EXCLUSIVE
+ //#define JUCE_WASAPI_EXCLUSIVE 0
+#endif
+
+#ifndef    JUCE_DIRECTSOUND
+ //#define JUCE_DIRECTSOUND 1
+#endif
+
+#ifndef    JUCE_ALSA
+ //#define JUCE_ALSA 1
+#endif
+
+#ifndef    JUCE_JACK
+ //#define JUCE_JACK 0
+#endif
+
+#ifndef    JUCE_BELA
+ //#define JUCE_BELA 0
+#endif
+
+#ifndef    JUCE_USE_ANDROID_OBOE
+ //#define JUCE_USE_ANDROID_OBOE 0
+#endif
+
+#ifndef    JUCE_USE_ANDROID_OPENSLES
+ //#define JUCE_USE_ANDROID_OPENSLES 0
+#endif
+
+#ifndef    JUCE_DISABLE_AUDIO_MIXING_WITH_OTHER_APPS
+ //#define JUCE_DISABLE_AUDIO_MIXING_WITH_OTHER_APPS 0
+#endif
+
+//==============================================================================
+// juce_audio_formats flags:
+
+#ifndef    JUCE_USE_FLAC
+ //#define JUCE_USE_FLAC 1
+#endif
+
+#ifndef    JUCE_USE_OGGVORBIS
+ //#define JUCE_USE_OGGVORBIS 1
+#endif
+
+#ifndef    JUCE_USE_MP3AUDIOFORMAT
+ //#define JUCE_USE_MP3AUDIOFORMAT 0
+#endif
+
+#ifndef    JUCE_USE_LAME_AUDIO_FORMAT
+ //#define JUCE_USE_LAME_AUDIO_FORMAT 0
+#endif
+
+#ifndef    JUCE_USE_WINDOWS_MEDIA_FORMAT
+ //#define JUCE_USE_WINDOWS_MEDIA_FORMAT 1
+#endif
+
+//==============================================================================
+// juce_audio_plugin_client flags:
+
+#ifndef    JUCE_VST3_CAN_REPLACE_VST2
+ //#define JUCE_VST3_CAN_REPLACE_VST2 1
+#endif
+
+#ifndef    JUCE_FORCE_USE_LEGACY_PARAM_IDS
+ //#define JUCE_FORCE_USE_LEGACY_PARAM_IDS 0
+#endif
+
+#ifndef    JUCE_FORCE_LEGACY_PARAMETER_AUTOMATION_TYPE
+ //#define JUCE_FORCE_LEGACY_PARAMETER_AUTOMATION_TYPE 0
+#endif
+
+#ifndef    JUCE_USE_STUDIO_ONE_COMPATIBLE_PARAMETERS
+ //#define JUCE_USE_STUDIO_ONE_COMPATIBLE_PARAMETERS 1
+#endif
+
+#ifndef    JUCE_STANDALONE_FILTER_WINDOW_USE_KIOSK_MODE
+ //#define JUCE_STANDALONE_FILTER_WINDOW_USE_KIOSK_MODE 0
+#endif
+
+//==============================================================================
+// juce_audio_processors flags:
+
+#ifndef    JUCE_PLUGINHOST_VST
+ #define   JUCE_PLUGINHOST_VST 1
+#endif
+
+#ifndef    JUCE_PLUGINHOST_VST3
+ #define   JUCE_PLUGINHOST_VST3 1
+#endif
+
+#ifndef    JUCE_PLUGINHOST_AU
+ #define   JUCE_PLUGINHOST_AU 1
+#endif
+
+#ifndef    JUCE_PLUGINHOST_LADSPA
+ //#define JUCE_PLUGINHOST_LADSPA 0
+#endif
+
+//==============================================================================
+// juce_audio_utils flags:
+
+#ifndef    JUCE_USE_CDREADER
+ //#define JUCE_USE_CDREADER 0
+#endif
+
+#ifndef    JUCE_USE_CDBURNER
+ //#define JUCE_USE_CDBURNER 0
+#endif
+
+//==============================================================================
+// juce_core flags:
+
+#ifndef    JUCE_FORCE_DEBUG
+ //#define JUCE_FORCE_DEBUG 0
+#endif
+
+#ifndef    JUCE_LOG_ASSERTIONS
+ //#define JUCE_LOG_ASSERTIONS 0
+#endif
+
+#ifndef    JUCE_CHECK_MEMORY_LEAKS
+ //#define JUCE_CHECK_MEMORY_LEAKS 1
+#endif
+
+#ifndef    JUCE_DONT_AUTOLINK_TO_WIN32_LIBRARIES
+ //#define JUCE_DONT_AUTOLINK_TO_WIN32_LIBRARIES 0
+#endif
+
+#ifndef    JUCE_INCLUDE_ZLIB_CODE
+ //#define JUCE_INCLUDE_ZLIB_CODE 1
+#endif
+
+#ifndef    JUCE_USE_CURL
+ //#define JUCE_USE_CURL 1
+#endif
+
+#ifndef    JUCE_LOAD_CURL_SYMBOLS_LAZILY
+ //#define JUCE_LOAD_CURL_SYMBOLS_LAZILY 0
+#endif
+
+#ifndef    JUCE_CATCH_UNHANDLED_EXCEPTIONS
+ //#define JUCE_CATCH_UNHANDLED_EXCEPTIONS 0
+#endif
+
+#ifndef    JUCE_ALLOW_STATIC_NULL_VARIABLES
+ //#define JUCE_ALLOW_STATIC_NULL_VARIABLES 0
+#endif
+
+#ifndef    JUCE_STRICT_REFCOUNTEDPOINTER
+ //#define JUCE_STRICT_REFCOUNTEDPOINTER 0
+#endif
+
+//==============================================================================
+// juce_dsp flags:
+
+#ifndef    JUCE_ASSERTION_FIRFILTER
+ //#define JUCE_ASSERTION_FIRFILTER 1
+#endif
+
+#ifndef    JUCE_DSP_USE_INTEL_MKL
+ //#define JUCE_DSP_USE_INTEL_MKL 0
+#endif
+
+#ifndef    JUCE_DSP_USE_SHARED_FFTW
+ //#define JUCE_DSP_USE_SHARED_FFTW 0
+#endif
+
+#ifndef    JUCE_DSP_USE_STATIC_FFTW
+ //#define JUCE_DSP_USE_STATIC_FFTW 0
+#endif
+
+#ifndef    JUCE_DSP_ENABLE_SNAP_TO_ZERO
+ //#define JUCE_DSP_ENABLE_SNAP_TO_ZERO 1
+#endif
+
+//==============================================================================
+// juce_events flags:
+
+#ifndef    JUCE_EXECUTE_APP_SUSPEND_ON_IOS_BACKGROUND_TASK
+ //#define JUCE_EXECUTE_APP_SUSPEND_ON_IOS_BACKGROUND_TASK 0
+#endif
+
+//==============================================================================
+// juce_graphics flags:
+
+#ifndef    JUCE_USE_COREIMAGE_LOADER
+ //#define JUCE_USE_COREIMAGE_LOADER 1
+#endif
+
+#ifndef    JUCE_USE_DIRECTWRITE
+ //#define JUCE_USE_DIRECTWRITE 1
+#endif
+
+#ifndef    JUCE_DISABLE_COREGRAPHICS_FONT_SMOOTHING
+ //#define JUCE_DISABLE_COREGRAPHICS_FONT_SMOOTHING 0
+#endif
+
+//==============================================================================
+// juce_gui_basics flags:
+
+#ifndef    JUCE_ENABLE_REPAINT_DEBUGGING
+ //#define JUCE_ENABLE_REPAINT_DEBUGGING 0
+#endif
+
+#ifndef    JUCE_USE_XRANDR
+ //#define JUCE_USE_XRANDR 1
+#endif
+
+#ifndef    JUCE_USE_XINERAMA
+ //#define JUCE_USE_XINERAMA 1
+#endif
+
+#ifndef    JUCE_USE_XSHM
+ //#define JUCE_USE_XSHM 1
+#endif
+
+#ifndef    JUCE_USE_XRENDER
+ //#define JUCE_USE_XRENDER 0
+#endif
+
+#ifndef    JUCE_USE_XCURSOR
+ //#define JUCE_USE_XCURSOR 1
+#endif
+
+#ifndef    JUCE_WIN_PER_MONITOR_DPI_AWARE
+ //#define JUCE_WIN_PER_MONITOR_DPI_AWARE 1
+#endif
+
+//==============================================================================
+// juce_gui_extra flags:
+
+#ifndef    JUCE_WEB_BROWSER
+ //#define JUCE_WEB_BROWSER 1
+#endif
+
+#ifndef    JUCE_ENABLE_LIVE_CONSTANT_EDITOR
+ //#define JUCE_ENABLE_LIVE_CONSTANT_EDITOR 0
+#endif
+
+//==============================================================================
+// kv_engines flags:
+
+#ifndef    KV_JACK_AUDIO
+ //#define KV_JACK_AUDIO 0
+#endif
+
+//==============================================================================
+// kv_gui flags:
+
+#ifndef    KV_DOCKING_WINDOWS
+ #define   KV_DOCKING_WINDOWS 1
+#endif
+
+//==============================================================================
+// Audio plugin settings..
+
+#ifndef  JucePlugin_Build_VST
+ #define JucePlugin_Build_VST              0
+#endif
+#ifndef  JucePlugin_Build_VST3
+ #define JucePlugin_Build_VST3             0
+#endif
+#ifndef  JucePlugin_Build_AU
+ #define JucePlugin_Build_AU               1
+#endif
+#ifndef  JucePlugin_Build_AUv3
+ #define JucePlugin_Build_AUv3             0
+#endif
+#ifndef  JucePlugin_Build_RTAS
+ #define JucePlugin_Build_RTAS             0
+#endif
+#ifndef  JucePlugin_Build_AAX
+ #define JucePlugin_Build_AAX              0
+#endif
+#ifndef  JucePlugin_Build_Standalone
+ #define JucePlugin_Build_Standalone       0
+#endif
+#ifndef  JucePlugin_Build_Unity
+ #define JucePlugin_Build_Unity            0
+#endif
+#ifndef  JucePlugin_Enable_IAA
+ #define JucePlugin_Enable_IAA             0
+#endif
+#ifndef  JucePlugin_Name
+ #define JucePlugin_Name                   "Element MFX"
+#endif
+#ifndef  JucePlugin_Desc
+ #define JucePlugin_Desc                   "Element Modular Effects Rack"
+#endif
+#ifndef  JucePlugin_Manufacturer
+ #define JucePlugin_Manufacturer           "Kushview"
+#endif
+#ifndef  JucePlugin_ManufacturerWebsite
+ #define JucePlugin_ManufacturerWebsite    "https://kushview.net"
+#endif
+#ifndef  JucePlugin_ManufacturerEmail
+ #define JucePlugin_ManufacturerEmail      "support@kushview.net"
+#endif
+#ifndef  JucePlugin_ManufacturerCode
+ #define JucePlugin_ManufacturerCode       0x4b736856 // 'KshV'
+#endif
+#ifndef  JucePlugin_PluginCode
+ #define JucePlugin_PluginCode             0x456c4d58 // 'ElMX'
+#endif
+#ifndef  JucePlugin_IsSynth
+ #define JucePlugin_IsSynth                0
+#endif
+#ifndef  JucePlugin_WantsMidiInput
+ #define JucePlugin_WantsMidiInput         1
+#endif
+#ifndef  JucePlugin_ProducesMidiOutput
+ #define JucePlugin_ProducesMidiOutput     1
+#endif
+#ifndef  JucePlugin_IsMidiEffect
+ #define JucePlugin_IsMidiEffect           1
+#endif
+#ifndef  JucePlugin_EditorRequiresKeyboardFocus
+ #define JucePlugin_EditorRequiresKeyboardFocus  0
+#endif
+#ifndef  JucePlugin_Version
+ #define JucePlugin_Version                1.44.0
+#endif
+#ifndef  JucePlugin_VersionCode
+ #define JucePlugin_VersionCode            0x12c00
+#endif
+#ifndef  JucePlugin_VersionString
+ #define JucePlugin_VersionString          "1.44.0"
+#endif
+#ifndef  JucePlugin_VSTUniqueID
+ #define JucePlugin_VSTUniqueID            JucePlugin_PluginCode
+#endif
+#ifndef  JucePlugin_VSTCategory
+ #define JucePlugin_VSTCategory            kPlugCategEffect
+#endif
+#ifndef  JucePlugin_Vst3Category
+ #define JucePlugin_Vst3Category           "Fx"
+#endif
+#ifndef  JucePlugin_AUMainType
+ #define JucePlugin_AUMainType             'aumi'
+#endif
+#ifndef  JucePlugin_AUSubType
+ #define JucePlugin_AUSubType              JucePlugin_PluginCode
+#endif
+#ifndef  JucePlugin_AUExportPrefix
+ #define JucePlugin_AUExportPrefix         ElementMFX
+#endif
+#ifndef  JucePlugin_AUExportPrefixQuoted
+ #define JucePlugin_AUExportPrefixQuoted   "ElementMFX"
+#endif
+#ifndef  JucePlugin_AUManufacturerCode
+ #define JucePlugin_AUManufacturerCode     JucePlugin_ManufacturerCode
+#endif
+#ifndef  JucePlugin_CFBundleIdentifier
+ #define JucePlugin_CFBundleIdentifier     net.kushview.plugins.ElementMFX
+#endif
+#ifndef  JucePlugin_RTASCategory
+ #define JucePlugin_RTASCategory           0
+#endif
+#ifndef  JucePlugin_RTASManufacturerCode
+ #define JucePlugin_RTASManufacturerCode   JucePlugin_ManufacturerCode
+#endif
+#ifndef  JucePlugin_RTASProductId
+ #define JucePlugin_RTASProductId          JucePlugin_PluginCode
+#endif
+#ifndef  JucePlugin_RTASDisableBypass
+ #define JucePlugin_RTASDisableBypass      0
+#endif
+#ifndef  JucePlugin_RTASDisableMultiMono
+ #define JucePlugin_RTASDisableMultiMono   0
+#endif
+#ifndef  JucePlugin_AAXIdentifier
+ #define JucePlugin_AAXIdentifier          net.kushview.ElementMFX
+#endif
+#ifndef  JucePlugin_AAXManufacturerCode
+ #define JucePlugin_AAXManufacturerCode    JucePlugin_ManufacturerCode
+#endif
+#ifndef  JucePlugin_AAXProductId
+ #define JucePlugin_AAXProductId           JucePlugin_PluginCode
+#endif
+#ifndef  JucePlugin_AAXCategory
+ #define JucePlugin_AAXCategory            8192
+#endif
+#ifndef  JucePlugin_AAXDisableBypass
+ #define JucePlugin_AAXDisableBypass       0
+#endif
+#ifndef  JucePlugin_AAXDisableMultiMono
+ #define JucePlugin_AAXDisableMultiMono    0
+#endif
+#ifndef  JucePlugin_IAAType
+ #define JucePlugin_IAAType                0x6175726d // 'aurm'
+#endif
+#ifndef  JucePlugin_IAASubType
+ #define JucePlugin_IAASubType             JucePlugin_PluginCode
+#endif
+#ifndef  JucePlugin_IAAName
+ #define JucePlugin_IAAName                "Kushview: Element MFX"
+#endif
+#ifndef  JucePlugin_VSTNumMidiInputs
+ #define JucePlugin_VSTNumMidiInputs       16
+#endif
+#ifndef  JucePlugin_VSTNumMidiOutputs
+ #define JucePlugin_VSTNumMidiOutputs      16
+#endif
+
+//==============================================================================
+#ifndef    JUCE_STANDALONE_APPLICATION
+ #if defined(JucePlugin_Name) && defined(JucePlugin_Build_Standalone)
+  #define  JUCE_STANDALONE_APPLICATION JucePlugin_Build_Standalone
+ #else
+  #define  JUCE_STANDALONE_APPLICATION 0
+ #endif
+#endif

--- a/tools/jucer/ElementMFX/JuceLibraryCode/JuceHeader.h
+++ b/tools/jucer/ElementMFX/JuceLibraryCode/JuceHeader.h
@@ -1,0 +1,61 @@
+/*
+
+    IMPORTANT! This file is auto-generated each time you save your
+    project - if you alter its contents, your changes may be overwritten!
+
+    This is the header file that your files should include in order to get all the
+    JUCE library headers. You should avoid including the JUCE headers directly in
+    your own source files, because that wouldn't pick up the correct configuration
+    options for your app.
+
+*/
+
+#pragma once
+
+#include "AppConfig.h"
+
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_audio_devices/juce_audio_devices.h>
+#include <juce_audio_formats/juce_audio_formats.h>
+#include <juce_audio_plugin_client/juce_audio_plugin_client.h>
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_audio_utils/juce_audio_utils.h>
+#include <juce_core/juce_core.h>
+#include <juce_cryptography/juce_cryptography.h>
+#include <juce_data_structures/juce_data_structures.h>
+#include <juce_dsp/juce_dsp.h>
+#include <juce_events/juce_events.h>
+#include <juce_graphics/juce_graphics.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <juce_gui_extra/juce_gui_extra.h>
+#include <juce_osc/juce_osc.h>
+#include <kv_core/kv_core.h>
+#include <kv_engines/kv_engines.h>
+#include <kv_gui/kv_gui.h>
+#include <kv_models/kv_models.h>
+
+
+#if defined (JUCE_PROJUCER_VERSION) && JUCE_PROJUCER_VERSION < JUCE_VERSION
+ /** If you've hit this error then the version of the Projucer that was used to generate this project is
+     older than the version of the JUCE modules being included. To fix this error, re-save your project
+     using the latest version of the Projucer or, if you aren't using the Projucer to manage your project,
+     remove the JUCE_PROJUCER_VERSION define from the AppConfig.h file.
+ */
+ #error "This project was last saved using an outdated version of the Projucer! Re-save this project with the latest version to fix this error."
+#endif
+
+#if ! DONT_SET_USING_JUCE_NAMESPACE
+ // If your code uses a lot of JUCE classes, then this will obviously save you
+ // a lot of typing, but can be disabled by setting DONT_SET_USING_JUCE_NAMESPACE.
+ using namespace juce;
+#endif
+
+#if ! JUCE_DONT_DECLARE_PROJECTINFO
+namespace ProjectInfo
+{
+    const char* const  projectName    = "Element MFX";
+    const char* const  companyName    = "Kushview";
+    const char* const  versionString  = "1.44.0";
+    const int          versionNumber  = 0x12c00;
+}
+#endif

--- a/tools/jucer/Standalone/Element.jucer
+++ b/tools/jucer/Standalone/Element.jucer
@@ -2,7 +2,7 @@
 
 <JUCERPROJECT id="UNteAW" name="Element" projectType="guiapp" version="0.44.0"
               bundleIdentifier="net.kushview.Element" includeBinaryInAppConfig="1"
-              jucerVersion="5.4.5" companyName="Kushview" companyWebsite="https://kushview.net"
+              jucerVersion="5.4.7" companyName="Kushview" companyWebsite="https://kushview.net"
               companyEmail="suport@kushview.net" displaySplashScreen="0" reportAppUsage="0"
               splashScreenColour="Dark" cppLanguageStandard="17" companyCopyright="Copyright (c) 2014-2020 Kushview, LLC"
               defines="EL_RUNNING_AS_PLUGIN=0&#10;EL_VERSION_STRING=&quot;0.44.0&quot;&#10;EL_USE_LUA=1&#10;"
@@ -653,9 +653,9 @@
                        targetName="Element" cppLibType="libc++" libraryPath="" binaryPath="../../../build/Debug"
                        defines="EL_USE_LOCAL_AUTH=0&#10;JLV2_PLUGINHOST_LV2=0&#10;"
                        enablePluginBinaryCopyStep="1" customXcodeFlags="ONLY_ACTIVE_ARCH=YES&#10;MACOSX_DEPLOYMENT_TARGET=10.8&#10;"
-                       headerPath="/opt/kushview/include" osxCompatibility="10.8 SDK"/>
+                       headerPath="/opt/kushview/include&#10;/usr/local/include" osxCompatibility="10.8 SDK"/>
         <CONFIGURATION name="Release" osxArchitecture="64BitIntel" isDebug="0" optimisation="2"
-                       targetName="Element" binaryPath="../../../build/Release" headerPath="/opt/kushview/include"
+                       targetName="Element" binaryPath="../../../build/Release" headerPath="/opt/kushview/include&#10;/usr/local/include"
                        libraryPath="" cppLibType="libc++" cppLanguageStandard="c++11"
                        defines="EL_USE_LOCAL_AUTH=0&#10;EL_SAVE_BINARY_FORMAT=1&#10;JLV2_PLUGINHOST_LV2=0&#10;"
                        fastMath="0" enablePluginBinaryCopyStep="1" customXcodeFlags="ONLY_ACTIVE_ARCH=YES,MACOSX_DEPLOYMENT_TARGET=10.8,OTHER_CODE_SIGN_FLAGS=--timestamp,CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO&#10;"
@@ -664,9 +664,9 @@
                        targetName="Element SE" cppLibType="libc++" libraryPath="" binaryPath="../../../build/Debug"
                        defines="EL_USE_LOCAL_AUTH=0&#10;JLV2_PLUGINHOST_LV2=0&#10;EL_SOLO=1"
                        enablePluginBinaryCopyStep="1" customXcodeFlags="ONLY_ACTIVE_ARCH=YES&#10;MACOSX_DEPLOYMENT_TARGET=10.8&#10;"
-                       headerPath="/opt/kushview/include" osxCompatibility="10.8 SDK"/>
+                       headerPath="/opt/kushview/include&#10;/usr/local/include" osxCompatibility="10.8 SDK"/>
         <CONFIGURATION name="Release_SE" osxArchitecture="64BitIntel" isDebug="0" optimisation="2"
-                       targetName="Element SE" binaryPath="../../../build/Release" headerPath="/opt/kushview/include"
+                       targetName="Element SE" binaryPath="../../../build/Release" headerPath="/opt/kushview/include&#10;/usr/local/include"
                        libraryPath="" cppLibType="libc++" cppLanguageStandard="c++11"
                        defines="EL_USE_LOCAL_AUTH=0&#10;EL_SAVE_BINARY_FORMAT=1&#10;JLV2_PLUGINHOST_LV2=0&#10;EL_SOLO=1&#10;"
                        fastMath="0" enablePluginBinaryCopyStep="1" customXcodeFlags="ONLY_ACTIVE_ARCH=YES,MACOSX_DEPLOYMENT_TARGET=10.8,OTHER_CODE_SIGN_FLAGS=--timestamp,CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO"


### PR DESCRIPTION
See #207 

Main change related to aumfx is the new subdir called "Element MFX".

In order to get this to build on my system I had to make a few other changes unrelated to auMFX, FYI:

1.  /usr/local/include added to header paths in order to find boost as installed by brew on OSX

2.  build/include was needed in some jucer files to find GitVersion.h

3.  Removed AAX targets because I don't currently have the AAX sdk.

4.  Cleaned up the jucer files for Element Standalone, ElementInst and ElementFX also, according to the same things as mentioned above so that they will all build, and also, it didn't make sense, for example, to build the standalone in the instrument jucer proj.

5.  For some reason, the ElementFX is not passing validation in LogicPro here, Debug assertions are crashing it.  I don't think its anything I did here, but could be wrong.
