### PR TITLE
Fixes #326 by calling update instead of repaing on block name change

### DIFF
--- a/src/gui/BlockComponent.cpp
+++ b/src/gui/BlockComponent.cpp
@@ -190,7 +190,7 @@ void BlockComponent::valueChanged (Value& value)
         repaint();
     } else if (nodeName.refersToSameSourceAs (value)) {
         setName (node.getName());
-        repaint();
+        update();
     } else if (hiddenPorts.refersToSameSourceAs (value)) {
         if (auto* ge = getGraphPanel())
             ge->updateComponents (false);


### PR DESCRIPTION
Since name changes can affect the block size, we should update instead of just repaint.