### PR TITLE
Fix build with gcc11

### DIFF
--- a/libs/lua/sol/sol.hpp
+++ b/libs/lua/sol/sol.hpp
@@ -37,6 +37,7 @@
 #include <sol/config.hpp>
 
 #include <cstdint>
+#include <limits>
 
 #define SOL_VERSION_MAJOR 3
 #define SOL_VERSION_MINOR 5


### PR DESCRIPTION
| ../git/libs/lua/sol/sol.hpp:9816:51: error: 'numeric_limits' is not a member of 'std'
|  9816 |                         std::size_t space = (std::numeric_limits<std::size_t>::max)();
|       |                                                   ^~~~~~~~~~~~~~

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>