### PR TITLE
Add a note about Apple Silicon

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -72,6 +72,13 @@ This produces `build/Applications/Element.app`.
 open build/Applications/Element.app
 ```
 
+__Apple Silicon__
+
+Replace the `./waf configure` command above with this:
+```
+./waf configure CPPFLAGS="-I/opt/homebrew/include"
+```
+
 __Test__
 ```
 ./waf check


### PR DESCRIPTION
Since all new Macs will require this step (unless the source is updated for the new homebrew installation dir `/opt/homebrew/` instead of `/usr/local/`.