### PR TITLE
Fix a problem that changed flag is turned on when only open session and do nothing.

### DIFF
--- a/src/controllers/SessionController.cpp
+++ b/src/controllers/SessionController.cpp
@@ -145,7 +145,7 @@ void SessionController::openFile (const File& file)
     {
         if (auto* gc = findSibling<GuiController>())
             gc->stabilizeContent();
-        changeResetter->triggerAsyncUpdate();
+        changeResetter->triggerAsyncUpdatePriority (MessagePriority::low);
     }
 }
 


### PR DESCRIPTION
One way to solve a problem that described #465 , I tried to implement a low priority system message queue.

By using this queue, in opening a session process, the processing of the `resetChanges` message can be delayed until later than other messages posted in the opening process. the low priority message queue is used only when the normal priority (original) message queue is empty at every message loop phase.

This PR needs to be applied with a PR (requested by https://github.com/kushview/JUCE/pull/1).

## Alternative way

The way described above is complexly. The problem is occurred when a component's ports state is changed, even if user doesn't perform any operation. Then, it might be a good idea to set `changedSinceSave` flag only when Elements is operated by user interactively. I think that when a component's  ports changed for some reason, user should fix the effects manually if it makes some problem.
