### PR TITLE
Better MIDI Handling in Lua

### DIFF
--- a/deploy/installer-linux.sh
+++ b/deploy/installer-linux.sh
@@ -3,13 +3,15 @@
 set -e
 rm -rf *.gz *.app *.dmg
 
-@BINARYCREATOR@ -v -c "@CONFIGFILE@" -p "@PACKAGES@" @INSTALLERBASE@
+@BINARYCREATOR@ -v -c "@CONFIGFILE@" -p "@PACKAGES@" @INSTALLERBASE@.run
 
 rm -rf archives && mkdir archives
 cd packages && @ARCHIVEGEN@ -f tar.gz -c 9 \
-    ../archives/element-linux.tar.gz \
+    ../archives/element-osx.tar.gz \
         net.kushview.element \
-        net.kushview.element.lua \
+        net.kushview.element.lua
+@ARCHIVEGEN@ -f tar.gz -c 9 \
+    ../archives/element-plugins-osx.tar.gz \
         net.kushview.element.vst \
         net.kushview.element.vst3
 

--- a/include/element/element.h
+++ b/include/element/element.h
@@ -19,13 +19,13 @@ extern "C" {
 #ifdef _WIN32
     // windows exports
     #if defined(EL_SHARED_BUILD)
-        #define EL_API __declspec(dllexport)
+        #define EL_API __declspec (dllexport)
         #pragma warning(disable : 4251)
     #elif defined(EL_SHARED)
-        #define EL_API __declspec(dllimport)
+        #define EL_API __declspec (dllimport)
         #pragma warning(disable : 4251)
     #endif
-    #define EL_PLUGIN_EXPORT EL_EXTERN __declspec(dllexport)
+    #define EL_PLUGIN_EXPORT EL_EXTERN __declspec (dllexport)
 #else
     #if defined(EL_SHARED) || defined(EL_SHARED_BUILD)
         #define EL_API __attribute__ ((visibility ("default")))
@@ -57,7 +57,7 @@ typedef enum {
 //==============================================================================
 #define EL_MT_AUDIO_BUFFER_64 "el.AudioBuffer64"
 #define EL_MT_AUDIO_BUFFER_32 "el.AudioBuffer32"
-#define EL_MT_BYTE_ARRAY      "el.ByteArray"
+#define EL_MT_BYTES           "el.Bytes"
 #define EL_MT_MIDI_MESSAGE    "el.MidiMessage"
 #define EL_MT_MIDI_BUFFER     "el.MidiBuffer"
 #define EL_MT_MIDI_PIPE       "el.MidiPipe"

--- a/include/element/element.h
+++ b/include/element/element.h
@@ -19,13 +19,13 @@ extern "C" {
 #ifdef _WIN32
     // windows exports
     #if defined(EL_SHARED_BUILD)
-        #define EL_API __declspec (dllexport)
+        #define EL_API __declspec(dllexport)
         #pragma warning(disable : 4251)
     #elif defined(EL_SHARED)
-        #define EL_API __declspec (dllimport)
+        #define EL_API __declspec(dllimport)
         #pragma warning(disable : 4251)
     #endif
-    #define EL_PLUGIN_EXPORT EL_EXTERN __declspec (dllexport)
+    #define EL_PLUGIN_EXPORT EL_EXTERN __declspec(dllexport)
 #else
     #if defined(EL_SHARED) || defined(EL_SHARED_BUILD)
         #define EL_API __attribute__ ((visibility ("default")))

--- a/src/el/MidiBuffer.cpp
+++ b/src/el/MidiBuffer.cpp
@@ -318,10 +318,10 @@ static const luaL_Reg buffer_methods[] = {
     { "insertPacked", midibuffer_insertPacked },
 
     // Insert some bytes into the buffer.
-    // The el.ByteArray passed in should contain a complete MIDI message
+    // The el.Bytes passed in should contain a complete MIDI message
     // of any type.
     // @function MidiBuffer:insertBytes
-    // @tparam el.ByteArray bytes The bytes to add
+    // @tparam el.Bytes bytes The bytes to add
     // @int size Max number of bytes to add
     // @int frame Sample position to insert at
     { "insertBytes", midibuffer_insertBytes },

--- a/src/el/MidiMessage.cpp
+++ b/src/el/MidiMessage.cpp
@@ -141,7 +141,7 @@ static int midimessage_data (lua_State* L)
 
 midimessage_is (sysex, isSysEx)
 
-static int midimessage_sysexData (lua_State* L)
+static int midimessage_sysExData (lua_State* L)
 {
     auto* msg = *(juce::MidiMessage**) lua_touserdata (L, 1);
     lua_pushlightuserdata (L, (void*) msg->getSysExData());
@@ -312,16 +312,16 @@ static const luaL_Reg midimessage_methods[] = {
     // @int ch Channel to set (1-16)
     { "setChannel", midimessage_set_channel },
 
-    /// Is sysex.
+    /// Is System Exclusive.
     // @function MidiMessage:isSysex
-    // @return True if is sysex message
+    // @return True if is SysEx message
     { "isSysex", midimessage_is_sysex },
 
     /// Sysex Data.
-    // @function MidiMessage:sysexData
+    // @function MidiMessage:sysExData
     // @return Raw sysex bytes
     // @return Sysex data size
-    { "sysexData", midimessage_sysexData },
+    { "sysExData", midimessage_sysExData },
 
     /// Is note on.
     // @function MidiMessage:isNoteOn

--- a/src/el/bytes.c
+++ b/src/el/bytes.c
@@ -85,6 +85,19 @@ static int f_get (lua_State* L)
     return 1;
 }
 
+/// Get a byte from the array.
+// This is the same as bytes.get() but for speed does not check for valid
+// argments.
+// @function rawget
+// @param bytes Bytes to get from
+// @int index Index in the array
+static int f_rawget (lua_State* L)
+{
+    EL_Bytes* b = (EL_Bytes*) lua_touserdata (L, 1);
+    lua_pushinteger (L, (lua_Integer) b->data[lua_tointeger (L, 2) - 1]);
+    return 1;
+}
+
 /// Set a byte in the array.
 // @function set
 // @param bytes Target bytes
@@ -101,6 +114,20 @@ static int f_set (lua_State* L)
     return 1;
 }
 
+/// Set a byte in the array.
+// This is the same as bytes.set() but for speed does not check for valid
+// arguments.
+// @function set
+// @param bytes Target bytes
+// @int index Index in the array
+// @int value Value to set in the range 0x00 to 0xFF inclusive
+static int f_rawset (lua_State* L)
+{
+    EL_Bytes* b = (EL_Bytes*) lua_touserdata (L, 1);
+    b->data[lua_tointeger (L, 2) - 1] = (uint8_t) lua_tointeger (L, 3);
+    return 1;
+}
+
 /// Returns the size in bytes.
 // @function size
 // @param bytes Target bytes
@@ -114,7 +141,8 @@ static int f_size (lua_State* L)
 }
 
 /// Pack 4 bytes in a 64bit integer.
-// Undefined params are treated as zero
+// Undefined params are treated as zero. This function does not check arguments
+// and therefor can crash if client code passes in bad data.
 // @function pack
 // @int b1 First byte
 // @int b2 Second byte
@@ -163,10 +191,16 @@ static int f_pack (lua_State* L)
 
 static const luaL_Reg bytes_f[] = {
     { "new", f_new },
+
     { "free", f_free },
     { "size", f_size },
+
     { "get", f_get },
+    { "rawget", f_rawget },
+
     { "set", f_set },
+    { "rawset", f_rawset },
+
     { "pack", f_pack },
     { NULL, NULL }
 };

--- a/src/el/bytes.c
+++ b/src/el/bytes.c
@@ -73,7 +73,7 @@ static int f_free (lua_State* L)
 
 /// Get a byte from the array.
 // @function get
-// @param bytes Bytes to get from
+// @tparam el.Bytes The Bytes to retrieve from
 // @int index Index in the array
 static int f_get (lua_State* L)
 {
@@ -85,12 +85,19 @@ static int f_get (lua_State* L)
     return 1;
 }
 
-/// Get a byte from raw memory.
-// This is the same as bytes.get() but can be used on raw memory
-// in the form of light userdata.
+/// Get a byte from a raw memory block.
 // @function rawget
-// @param bytes Bytes to get from
+// @tparam lightuserdata data Raw data pointer.
 // @int index Index in the array
+// @usage
+// -- Raw access is useful when reading MIDI data like SysEx.
+// local msg = get_the_message() -- msg is a `el.MidiMessage`
+// if msg:isSysEx() then
+//   local data, _ = msg:sysExData()
+//   -- its "1 + .." because MIDI channels start at one, and the data is zero indexed
+//   local sysexValue = bytes.rawget (data, 5)
+//   -- special sysex handling follows...
+// end
 static int f_rawget (lua_State* L)
 {
     uint8_t* data = (uint8_t*) lua_touserdata (L, 1);
@@ -100,7 +107,7 @@ static int f_rawget (lua_State* L)
 
 /// Set a byte in the array.
 // @function set
-// @param bytes Target bytes
+// @tparam el.Bytes obj The Bytes object to modify
 // @int index Index in the array
 // @int value Value to set in the range 0x00 to 0xFF inclusive
 static int f_set (lua_State* L)
@@ -115,10 +122,9 @@ static int f_set (lua_State* L)
 }
 
 /// Set a byte in the array.
-// This is the same as bytes.set() but can be used on raw memory
-// in the form of light userdata.
+// Sets a byte in a raw data buffer.
 // @function rawset
-// @param bytes Target bytes
+// @tparam lightuserdata data Target bytes to modify
 // @int index Index in the array
 // @int value Value to set in the range 0x00 to 0xFF inclusive
 static int f_rawset (lua_State* L)
@@ -134,13 +140,13 @@ static int f_rawset (lua_State* L)
 // @treturn el.Bytes The new byte array.
 static int f_toraw (lua_State* L)
 {
-    lua_pushlightuserdata (L, ((EL_Bytes*)lua_touserdata (L, 1))->data);
+    lua_pushlightuserdata (L, ((EL_Bytes*) lua_touserdata (L, 1))->data);
     return 1;
 }
 
 /// Returns the size in bytes.
 // @function size
-// @param bytes Target bytes
+// @tparam el.Bytes obj The Bytes object to check.
 // @treturn int The size in bytes.
 static int f_size (lua_State* L)
 {

--- a/src/el/bytes.c
+++ b/src/el/bytes.c
@@ -54,10 +54,14 @@ void element_bytes_set (EL_Bytes* b, lua_Integer index, uint8_t value)
 // @treturn kv.ByteArray The new byte array.
 static int f_new (lua_State* L)
 {
-    EL_Bytes* b = (EL_Bytes*) lua_newuserdata (L, sizeof (EL_Bytes));
-    luaL_setmetatable (L, EL_MT_BYTE_ARRAY);
+    // EL_Bytes* b = (EL_Bytes*) lua_newuserdata (L, sizeof (EL_Bytes));
+    // luaL_setmetatable (L, EL_MT_BYTE_ARRAY);
+    
     size_t size = lua_isnumber (L, 1) ? (size_t) lua_tonumber (L, 1) : 0;
-    element_bytes_init (b, size);
+    // element_bytes_init (b, size);
+    uint8_t* data = (uint8_t*) lua_newuserdata (L, size);
+    memset (data, size, sizeof (uint8_t));
+    lua_pushlightuserdata (L, data);
     return 1;
 }
 
@@ -93,8 +97,8 @@ static int f_get (lua_State* L)
 // @int index Index in the array
 static int f_rawget (lua_State* L)
 {
-    EL_Bytes* b = (EL_Bytes*) lua_touserdata (L, 1);
-    lua_pushinteger (L, (lua_Integer) b->data[lua_tointeger (L, 2) - 1]);
+    uint8_t* data = (uint8_t*) lua_touserdata (L, 1);
+    lua_pushinteger (L, (lua_Integer) data[lua_tointeger (L, 2) - 1]);
     return 1;
 }
 
@@ -123,8 +127,8 @@ static int f_set (lua_State* L)
 // @int value Value to set in the range 0x00 to 0xFF inclusive
 static int f_rawset (lua_State* L)
 {
-    EL_Bytes* b = (EL_Bytes*) lua_touserdata (L, 1);
-    b->data[lua_tointeger (L, 2) - 1] = (uint8_t) lua_tointeger (L, 3);
+    uint8_t* data = (uint8_t*) lua_touserdata (L, 1);
+    data[lua_tointeger (L, 2) - 1] = (uint8_t) lua_tointeger (L, 3);
     return 1;
 }
 

--- a/src/el/midi.c
+++ b/src/el/midi.c
@@ -5,6 +5,8 @@
 // @author Michael Fisher
 // @module el.midi
 
+#include <math.h>
+
 #include "element/element.h"
 #include <lauxlib.h>
 
@@ -79,12 +81,36 @@ static int f_noteoff (lua_State* L)
     return f_msg3bytes (L, 0x80);
 }
 
-static int f_tohertz (lua_State* L)
+/// Make a program change message.
+// @function programchange
+// @int channel MIDI Channel
+// @int program Program number
+// @return MIDI message packed as Integer
+// @within Messages
+static int f_programchange (lua_State* L)
 {
-    lua_pushinteger (L, 0);
-    return 0;
+    lua_pushinteger (L, 0x00);
+    return f_msg3bytes (L, 0xC0);
 }
 
+/// Convert a MIDI note to hertz.
+// This version assumes A 440 Hz
+// @function tohertz
+// @int note Note number
+// @return Value in hertz
+// @within Utils
+static int f_tohertz (lua_State* L)
+{
+    double value = 440.0 * pow (2.0, (lua_tointeger (L, 1) - 69) / 12.0);
+    lua_pushnumber (L, value);
+    return 1;
+}
+
+/// Clamp to a valid MIDI value (0 - 127)
+// @function clamp
+// @int value The value to clamp
+// @return The clamped value.
+// @within Utils
 static int f_clamp (lua_State* L)
 {
     lua_Integer value = lua_tointeger (L, 1);
@@ -100,6 +126,7 @@ static const luaL_Reg midi_f[] = {
     { "controller", f_controller },
     { "noteon", f_noteon },
     { "noteoff", f_noteoff },
+    { "programchange", f_programchange },
     { "tohertz", f_tohertz },
     { "clamp", f_clamp },
     { NULL, NULL }

--- a/src/el/midi.c
+++ b/src/el/midi.c
@@ -1,7 +1,9 @@
 // Copyright 2023 Kushview, LLC <info@kushview.net>
 // SPDX-License-Identifier: GPL3-or-later
 
-/// MIDI utilities.
+/// MIDI factories and utilities.
+// Functions in this module **do not** check arguments. It is the responsibility
+// of calling code to ensure correct data is passed.
 // @author Michael Fisher
 // @module el.midi
 
@@ -82,15 +84,141 @@ static int f_noteoff (lua_State* L)
 }
 
 /// Make a program change message.
-// @function programchange
-// @int channel MIDI Channel
+// @function program
+// @int channel The midi channel (1 to 16)
 // @int program Program number
 // @return MIDI message packed as Integer
 // @within Messages
-static int f_programchange (lua_State* L)
+static int f_program (lua_State* L)
 {
     lua_pushinteger (L, 0x00);
     return f_msg3bytes (L, 0xC0);
+}
+
+/// Make a pitch wheel message.
+// @function pitch
+// @int channel The midi channel (1 to 16)
+// @int position The wheel position, in the range 0 to 16383
+// @return MIDI message packed as Integer
+// @within Messages
+static int f_pitch (lua_State* L)
+{
+    lua_Integer position = lua_tointeger (L, 2);
+    PackedMessage msg = { .packed = 0x00 };
+    msg.data.byte1 = 0xE0 | (uint8_t) (lua_tointeger (L, 1) - 1);
+    msg.data.byte2 = (uint8_t) (position & 127);
+    msg.data.byte2 = (uint8_t) ((position >> 7) & 127);
+    msg.data.byte2 = 0x00;
+    lua_pushinteger (L, msg.packed);
+    return 1;
+}
+
+/// Make an after touch message.
+// @function aftertouch
+// @int channel The midi channel (1 to 16)
+// @int note The midi note, in the range 0 to 127
+// @int value The after touch value.
+// @return MIDI message packed as Integer
+// @within Messages
+static int f_aftertouch (lua_State* L)
+{
+    return f_msg3bytes (L, 0xA0);
+}
+
+/// Make a channel-pressure message.
+// @function channelpressure
+// @int channel The midi channel (1 to 16)
+// @int value The pressure value (0 to 127)
+// @return MIDI message packed as Integer
+// @within Messages
+static int f_channelpressure (lua_State* L)
+{
+    lua_pushinteger (L, 0x00);
+    return f_msg3bytes (L, 0x00);
+}
+
+/// Make an all notes off message.
+// @function allnotesoff
+// @int channel The midi channel (1 to 16)
+// @return MIDI message packed as Integer
+// @within Messages
+static int f_allnotesoff (lua_State* L)
+{
+    lua_pushinteger (L, 123);
+    lua_pushinteger (L, 0);
+    return f_controller (L);
+}
+
+/// Make an all sounds off message.
+// @function allsoundsoff
+// @int channel   The midi channel (1 to 16)
+// @return MIDI message packed as Integer
+// @within Messages
+static int f_allsoundsoff (lua_State* L)
+{
+    lua_pushinteger (L, 120);
+    lua_pushinteger (L, 0);
+    return f_controller (L);
+}
+
+/// Make an all controllers off message.
+// @function allcontrollersoff
+// @int channel   The midi channel (1 to 16)
+// @return MIDI message packed as Integer
+// @within Messages
+static int f_allcontrollersoff (lua_State* L)
+{
+    lua_pushinteger (L, 121);
+    lua_pushinteger (L, 0);
+    return f_controller (L);
+}
+
+/// Make a clock message.
+// @function clock
+// @return MIDI message packed as Integer
+// @within Messages
+static int f_clock (lua_State* L)
+{
+    PackedMessage msg = { .packed = 0x00 };
+    msg.data.byte1 = 0xF8;
+    lua_pushinteger (L, msg.packed);
+    return 1;
+}
+
+/// Make a start message.
+// @function start
+// @return MIDI message packed as Integer
+// @within Messages
+static int f_start (lua_State* L)
+{
+    PackedMessage msg = { .packed = 0x00 };
+    msg.data.byte1 = 0xFA;
+    lua_pushinteger (L, msg.packed);
+    return 1;
+}
+
+/// Make a stop message.
+// @function stop
+// @return MIDI message packed as Integer
+// @within Messages
+static int f_stop (lua_State* L)
+{
+    PackedMessage msg = { .packed = 0x00 };
+    msg.data.byte1 = 0xFC;
+    lua_pushinteger (L, msg.packed);
+    return 1;
+}
+
+/// Make a continue message.
+// @function continue
+// @return MIDI message packed as Integer
+// @within Messages
+static int f_continue (lua_State* L)
+{
+    PackedMessage msg = { .packed = 0x00 };
+    msg.data.byte1 = 0xFB;
+    lua_pushinteger (L, msg.packed);
+    return 1;
 }
 
 /// Convert a MIDI note to hertz.
@@ -101,7 +229,7 @@ static int f_programchange (lua_State* L)
 // @within Utils
 static int f_tohertz (lua_State* L)
 {
-    double value = 440.0 * pow (2.0, (lua_tointeger (L, 1) - 69) / 12.0);
+    lua_Number value = 440.0 * pow (2.0, (lua_tointeger (L, 1) - 69) / 12.0);
     lua_pushnumber (L, value);
     return 1;
 }
@@ -126,7 +254,21 @@ static const luaL_Reg midi_f[] = {
     { "controller", f_controller },
     { "noteon", f_noteon },
     { "noteoff", f_noteoff },
-    { "programchange", f_programchange },
+    { "program", f_program },
+    { "pitch", f_pitch },
+
+    { "aftertouch", f_aftertouch },
+    { "channelpressure", f_channelpressure },
+
+    { "allnotesoff", f_allnotesoff },
+    { "allsoundsoff", f_allsoundsoff },
+    { "allcontrollersoff", f_allcontrollersoff },
+
+    { "clock", f_clock },
+    { "start", f_start },
+    { "stop", f_stop },
+    { "continue", f_continue },
+
     { "tohertz", f_tohertz },
     { "clamp", f_clamp },
     { NULL, NULL }

--- a/src/nodes/scriptnode.hpp
+++ b/src/nodes/scriptnode.hpp
@@ -60,6 +60,7 @@ private:
     CodeDocument dspCode, edCode;
     std::unique_ptr<DSPScript> script;
     ParameterArray inParams, outParams;
+    StringArray printMessages;
 
     int _program = 0;
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -24,6 +24,7 @@ test_element_sources = '''
     scripting/scriptloadertest.cpp
     scripting/scriptmanagertest.cpp
     scripting/scriptplayground.cpp
+    scripting/bytestest.cpp
 
     updatetests.cpp
     porttypetests.cpp
@@ -69,8 +70,9 @@ test ('Shuttle',        test_element_app, args: [ '-t', 'ShuttleTests' ],       
 test ('ToggleGrid',     test_element_app, args: [ '-t', 'ToggleGridTest'],      suite: 'engine' )
 test ('VelocityCurve',  test_element_app, args: [ '-t', 'VelocityCurveTest'],   suite: 'engine' )
 
-test ('DSPScript',      test_element_app, args: [ '-t', 'DSPScriptTest' ],     suite: 'lua')
-test ('ScriptInfo',     test_element_app, args: [ '-t', 'ScriptInfoTest' ],    suite: 'lua')
-test ('ScriptManager',  test_element_app, args: [ '-t', 'ScriptManagerTest' ], suite: 'lua')
-test ('ScriptLoader',   test_element_app, args: [ '-t', 'ScriptLoaderTest' ],  suite: 'lua')
-test ('ScriptPlayground', test_element_app, args: [ '-t', 'ScriptPlayground' ],  suite: 'lua')
+test ('Bytes',          test_element_app, args: [ '-t', 'BytesTest' ],          suite: 'lua')
+test ('DSPScript',      test_element_app, args: [ '-t', 'DSPScriptTest' ],      suite: 'lua')
+test ('ScriptInfo',     test_element_app, args: [ '-t', 'ScriptInfoTest' ],     suite: 'lua')
+test ('ScriptManager',  test_element_app, args: [ '-t', 'ScriptManagerTest' ],  suite: 'lua')
+test ('ScriptLoader',   test_element_app, args: [ '-t', 'ScriptLoaderTest' ],   suite: 'lua')
+test ('ScriptPlayground', test_element_app, args: [ '-t', 'ScriptPlayground' ], suite: 'lua')

--- a/test/scripting/bytestest.cpp
+++ b/test/scripting/bytestest.cpp
@@ -17,11 +17,11 @@ BOOST_AUTO_TEST_CASE (Basics)
     LuaFixture fix;
     sol::state_view lua (fix.luaState());
     auto script = fix.readSnippet ("test_bytes.lua");
-    BOOST_REQUIRE(!script.isEmpty());
+    BOOST_REQUIRE (! script.isEmpty());
     try {
         lua.safe_script (script.toRawUTF8(), "[test:bytes]");
     } catch (const std::exception& e) {
-        BOOST_REQUIRE_MESSAGE(false, e.what());
+        BOOST_REQUIRE_MESSAGE (false, e.what());
     }
 }
 

--- a/test/scripting/bytestest.cpp
+++ b/test/scripting/bytestest.cpp
@@ -1,0 +1,28 @@
+// Copyright 2023 Kushview, LLC <info@kushview.net>
+// SPDX-License-Identifier: GPL3-or-later
+
+#include <boost/test/unit_test.hpp>
+
+#include "luatest.hpp"
+#include "scripting/dspscript.hpp"
+#include "scripting/scriptloader.hpp"
+#include "testutil.hpp"
+
+using namespace element;
+
+BOOST_AUTO_TEST_SUITE (BytesTest)
+
+BOOST_AUTO_TEST_CASE (Basics)
+{
+    LuaFixture fix;
+    sol::state_view lua (fix.luaState());
+    auto script = fix.readSnippet ("test_bytes.lua");
+    BOOST_REQUIRE(!script.isEmpty());
+    try {
+        lua.safe_script (script.toRawUTF8(), "[test:bytes]");
+    } catch (const std::exception& e) {
+        BOOST_REQUIRE_MESSAGE(false, e.what());
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/snippets/test_bytes.lua
+++ b/test/snippets/test_bytes.lua
@@ -2,14 +2,20 @@ local bytes = require ('el.bytes')
 local data = bytes.new (1024)
 
 BOOST_REQUIRE (data ~= nil)
-bytes.set (data, 1, 0xff)
-bytes.set (data, 2, 0xfe)
 bytes.rawset (data, 3, 0xfd)
+BOOST_REQUIRE (bytes.rawget (data, 3) == 0xfd)
 
-BOOST_REQUIRE (bytes.size (data) == 1024)
-BOOST_REQUIRE (bytes.get (data, 1) == 0xff)
-BOOST_REQUIRE (bytes.get (data, 2) == bytes.rawget (data, 2))
-BOOST_REQUIRE (bytes.get (data, 3) ~= bytes.rawget (data, 2))
-BOOST_REQUIRE (bytes.get (data, 2) ~= bytes.rawget (data, 1))
+return
 
-bytes.free (data)
+
+-- bytes.set (data, 1, 0xff)
+-- bytes.set (data, 2, 0xfe)
+
+
+-- BOOST_REQUIRE (bytes.size (data) == 1024)
+-- BOOST_REQUIRE (bytes.get (data, 1) == 0xff)
+-- BOOST_REQUIRE (bytes.get (data, 2) == bytes.rawget (data, 2))
+-- BOOST_REQUIRE (bytes.get (data, 3) ~= bytes.rawget (data, 2))
+-- BOOST_REQUIRE (bytes.get (data, 2) ~= bytes.rawget (data, 1))
+
+-- bytes.free (data)

--- a/test/snippets/test_bytes.lua
+++ b/test/snippets/test_bytes.lua
@@ -2,20 +2,24 @@ local bytes = require ('el.bytes')
 local data = bytes.new (1024)
 
 BOOST_REQUIRE (data ~= nil)
-bytes.rawset (data, 3, 0xfd)
-BOOST_REQUIRE (bytes.rawget (data, 3) == 0xfd)
 
-return
+bytes.set (data, 1, 0xff)
+bytes.set (data, 2, 0xfe)
+bytes.set (data, 3, 0xfd)
 
+BOOST_REQUIRE (bytes.size (data) == 1024)
+BOOST_REQUIRE (bytes.get (data, 1) == 0xff)
+BOOST_REQUIRE (bytes.get (data, 2) == bytes.get (data, 2))
+BOOST_REQUIRE (bytes.get (data, 3) ~= bytes.get (data, 2))
+BOOST_REQUIRE (bytes.get (data, 2) ~= bytes.get (data, 1))
 
--- bytes.set (data, 1, 0xff)
--- bytes.set (data, 2, 0xfe)
+local raw = bytes.toraw (data)
+bytes.rawset (raw, 1, 0x10)
+bytes.rawset (raw, 2, 0x11)
+bytes.rawset (raw, 3, 0x12)
+BOOST_REQUIRE (bytes.rawget (raw, 1) == 0x10)
+BOOST_REQUIRE (bytes.rawget (raw, 2) == bytes.get (data, 2))
+BOOST_REQUIRE (bytes.rawget (raw, 3) ~= bytes.get (data, 2))
+BOOST_REQUIRE (bytes.rawget (raw, 2) ~= bytes.get (data, 1))
 
-
--- BOOST_REQUIRE (bytes.size (data) == 1024)
--- BOOST_REQUIRE (bytes.get (data, 1) == 0xff)
--- BOOST_REQUIRE (bytes.get (data, 2) == bytes.rawget (data, 2))
--- BOOST_REQUIRE (bytes.get (data, 3) ~= bytes.rawget (data, 2))
--- BOOST_REQUIRE (bytes.get (data, 2) ~= bytes.rawget (data, 1))
-
--- bytes.free (data)
+bytes.free (data)

--- a/test/snippets/test_bytes.lua
+++ b/test/snippets/test_bytes.lua
@@ -1,0 +1,15 @@
+local bytes = require ('el.bytes')
+local data = bytes.new (1024)
+
+BOOST_REQUIRE (data ~= nil)
+bytes.set (data, 1, 0xff)
+bytes.set (data, 2, 0xfe)
+bytes.rawset (data, 3, 0xfd)
+
+BOOST_REQUIRE (bytes.size (data) == 1024)
+BOOST_REQUIRE (bytes.get (data, 1) == 0xff)
+BOOST_REQUIRE (bytes.get (data, 2) == bytes.rawget (data, 2))
+BOOST_REQUIRE (bytes.get (data, 3) ~= bytes.rawget (data, 2))
+BOOST_REQUIRE (bytes.get (data, 2) ~= bytes.rawget (data, 1))
+
+bytes.free (data)


### PR DESCRIPTION
A few nice additions to the Scripting engine.

- add access to raw bytes from `el.bytes`
- add more message factories to `el.midi`
- Tie Lua `print()` to the DSP side of a Script node.

Closes #726 
Closes #731 
Closes #727 
