### PR TITLE
session: fix save prompt on clean project load

### DIFF
--- a/src/services/sessionservice.cpp
+++ b/src/services/sessionservice.cpp
@@ -147,7 +147,8 @@ void SessionService::openFile (const File& file)
     if (didSomething)
     {
         if (auto* gc = sibling<GuiService>())
-            gc->stabilizeContent();
+            if (! file.hasFileExtension ("els"))
+                gc->stabilizeContent();
         changeResetter->triggerAsyncUpdate();
     }
 }


### PR DESCRIPTION
Skip the redundant stabilizeContent() call for .els files since they already call it inside the freeze scope during load.

Fixes #992