### PR TITLE
ui: convert file choosers to async to prevent crash

### DIFF
--- a/src/ui/filecombobox.hpp
+++ b/src/ui/filecombobox.hpp
@@ -213,6 +213,7 @@ private:
     String wildcard, enforcedSuffix, browseButtonText;
     juce::ListenerList<FileComboBoxListener> listeners;
     File defaultBrowseFile;
+    std::unique_ptr<juce::FileChooser> chooser;
 
     void showChooser();
     void handleAsyncUpdate() override;


### PR DESCRIPTION
Use async file choosers with SafePointer callback guards to prevent crash when component is deleted while dialog is open.

Fixes #870