### PR TITLE
Fix GCC 15 Build Error - Incomplete Type in std::unique_ptr

### DIFF
--- a/include/element/application.hpp
+++ b/include/element/application.hpp
@@ -6,10 +6,10 @@
 #include <element/juce/core.hpp>
 #include <element/juce/events.hpp>
 #include <element/juce/gui_basics.hpp>
+#include <element/ui/content.hpp>
 
 namespace element {
 
-class ContentFactory;
 class Context;
 class Startup;
 


### PR DESCRIPTION
### 1. What Has Been Changed

Added `#include <element/ui/content.hpp>` to [include/element/application.hpp](cci:7://file:///home/bzeiss/develop/element.worktrees/fedora43-fixes/include/element/application.hpp:0:0-0:0) to provide the complete definition of [ContentFactory](cci:2://file:///home/bzeiss/develop/element.worktrees/fedora43-fixes/include/element/ui/content.hpp:146:0-180:1) before its use with `std::unique_ptr`.

### 2. Why It Has Been Changed / Points Addressed

**Issue:** Build failure on Fedora 43 with GCC 15:
```
error: invalid application of 'sizeof' to incomplete type 'element::ContentFactory'
```

**Root Cause:** The [Application::createContentFactory()](cci:1://file:///home/bzeiss/develop/element.worktrees/fedora43-fixes/include/element/application.hpp:111:4-111:86) method returns `std::unique_ptr<ContentFactory>` initialized with `nullptr`. When constructing this `unique_ptr`, the compiler instantiates `std::default_delete<ContentFactory>`, which requires the complete type definition. Previously, only a forward declaration was available at that point.

**Standard Compliance:** GCC 15 enforces the C++ standard requirement more strictly than older compilers. The standard requires complete types for `std::unique_ptr` deleters, though some compilers were more lenient.

### 3. Test Recommendations / Test Ideas

- Build on GCC 15+ (Fedora 43, Arch with latest GCC) - confirmed
- Build on older GCC versions (GCC 9, 10, 11, 13)
- Build on Clang (Linux, macOS)
- Build on MSVC (Windows)
- Verify all plugin formats still build correctly
- Run existing test suite to confirm no behavioral changes
