### PR TITLE
ci: switch Windows runner to MSVC 2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,10 +138,10 @@ jobs:
           -DELEMENT_ENABLE_ASIO=ON `
           -DELEMENT_ENABLE_UPDATER=ON `
           -DELEMENT_BUILD_PLUGINS=ON `
-          -DBoost_INCLUDE_DIR="C:/local/boost" `
-          -DBoost_LIBRARY_DIRS="C:/local/boost/lib64-msvc-14.3"
+          -DBoost_INCLUDE_DIR="C:/local/boost_1_87_0" `
+          -DBoost_LIBRARY_DIRS="C:/local/boost_1_87_0/lib64-msvc-14.3"
       env:
-        BOOST_ROOT: C:/local/boost
+        BOOST_ROOT: C:/local/boost_1_87_0
     
     - name: Configure CMake (Unix)
       if: runner.os != 'Windows'


### PR DESCRIPTION
- Update matrix runner from windows-2019 to windows-2022
- Update Boost platform_version from 2019 to 2022
- Add explicit arch: amd64 to ilammy/msvc-dev-cmd
- Pass Boost_INCLUDE_DIR and Boost_LIBRARY_DIRS to CMake explicitly to fix header inclusion failures with the 2022 toolchain