### PR TITLE
Fix audio thread stuttering with large midi messages on Windows

### DIFF
--- a/src/engine/audioengine.cpp
+++ b/src/engine/audioengine.cpp
@@ -438,7 +438,7 @@ public:
                 {
                     midiIOMonitor->sent();
 #if JUCE_WINDOWS
-                    midiOut->sendBlockOfMessagesNow (tempMidi);
+                    midiOut->sendBlockOfMessages (tempMidi, delayMs + Time::getMillisecondCounter(), sampleRate);
 #else
                     midiOut->sendBlockOfMessages (tempMidi, delayMs + Time::getMillisecondCounterHiRes(), sampleRate);
 #endif

--- a/src/engine/midioutput.cpp
+++ b/src/engine/midioutput.cpp
@@ -123,7 +123,8 @@ juce::Result ElementMidiOutput::openDevice (const juce::MidiDeviceInfo& deviceIn
 juce::Result ElementMidiOutput::sendBlockOfMessages (const juce::MidiBuffer& midi, double delayMs, double sampleRate) const
 {
 #if JUCE_WINDOWS
-    output->sendBlockOfMessagesNow (midi);
+    output->sendBlockOfMessages (
+        midi, delayMs + juce::Time::getMillisecondCounter(), sampleRate);
 #else
     output->sendBlockOfMessages (
         midi, delayMs + juce::Time::getMillisecondCounterHiRes(), sampleRate);


### PR DESCRIPTION
Hello,
Thanks for this amazing software!

This PR fixes an audio thread stuttering problem when sending a large midi message on Windows.

When sending a thousand bytes SysEx, the audio thread was kept busy by `midiOut->sendBlockOfMessagesNow()`.
This causes a stuttering of the audio playback, because a 1000 bytes SysEx takes around 32ms to be sent,
hence blocking the audio thread. This is all the more noticeable with several-thousands-bytes SysEx.

This PR almost reverts cf2238c2d9ecf5156c633211445b8d5016642eec, but uses `Time::getMillisecondCounter()` instead of `Time::getMillisecondCounterHiRes()`, as suggested by [this juce discussion](https://forum.juce.com/t/weird-midi-output-latency-on-windows/51587/14).
Indeed, `ScheduledEventThread::run`, which is in charge of sending the midi messages on time, uses `Time::getMillisecondCounter()` to determine the current timestamp.

I am pretty confident this 'properly' resolves the original commit's issue https://github.com/kushview/element/issues/493, but I am not able to replicate the exact same setup to validate this. I, however, did not notice any side-effect during my testing.

Cheers,