### PR TITLE
Fix: Use the desktop scale in plugin window

### DIFF
--- a/src/ui/pluginwindow.cpp
+++ b/src/ui/pluginwindow.cpp
@@ -324,7 +324,7 @@ PluginWindow::~PluginWindow()
     setLookAndFeel (nullptr);
 }
 
-float PluginWindow::getDesktopScaleFactor() const { return 1.f; }
+float PluginWindow::getDesktopScaleFactor() const { return (float) juce::Desktop::getInstance().getGlobalScaleFactor(); }
 
 Content* PluginWindow::getElementContentComponent() const
 {


### PR DESCRIPTION
This makes sure that the plugin window itself follows the desktop scale set in the settings. This affects the size of the buttons at the top, and also the size of the contents of the built-in plugins.

<details>
<summary>Before vs after</summary>
Before
<img width="1350" height="806" alt="before" src="https://github.com/user-attachments/assets/036a38fd-89ad-4208-a1e1-d407f74baf51" />

After
<img width="1388" height="765" alt="after" src="https://github.com/user-attachments/assets/7f97471e-a941-4833-98e8-97d767c2b571" />
</details>

I have only tested in on Linux, so I'm not sure about the consequences on other operating systems.