### PR TITLE
Fix Audio Out node duplication & dead meters on re-add

### DIFF
--- a/src/engine/graphmanager.cpp
+++ b/src/engine/graphmanager.cpp
@@ -69,15 +69,25 @@ private:
         const bool wantsMidiIn = graph.getNumPorts (PortType::Midi, true) > 0;
         const bool wantsMidiOut = graph.getNumPorts (PortType::Midi, false) > 0;
 
+        Array<uint32> nodesToRemove;
+
         ProcessorPtr ioNodes[IONode::numDeviceTypes];
         for (int i = 0; i < manager.getNumNodes(); ++i)
         {
             ProcessorPtr node = manager.getNode (i);
             if (auto* ioProc = dynamic_cast<IONode*> (node.get()))
-                ioNodes[ioProc->getType()] = node;
+            {
+                const auto type = ioProc->getType();
+                // Keep the first IO node found for each type; any additional
+                // ones are duplicates (see the re-entrancy bug fixed in
+                // IONode::setParentGraph) and get removed below. This also
+                // repairs sessions already corrupted by that bug on load.
+                if (ioNodes[type] == nullptr)
+                    ioNodes[type] = node;
+                else
+                    nodesToRemove.add (node->nodeId);
+            }
         }
-
-        Array<uint32> nodesToRemove;
 
         for (int t = 0; t < IONode::numDeviceTypes; ++t)
         {

--- a/src/engine/graphnode.cpp
+++ b/src/engine/graphnode.cpp
@@ -98,13 +98,21 @@ Processor* GraphNode::addNode (Processor* newNode, uint32 nodeId)
             lastNodeId = nodeId;
     }
 
+    // Register the node before configuring it. setParentGraph() may synchronously
+    // adjust the parent graph's port count (for IO nodes), which re-enters
+    // IONodeEnforcer. That enforcer scans this same nodes array to decide which IO
+    // nodes are missing, so the node must already be present here or it gets added
+    // a second time (duplicate Audio In/Out). Keeping the port setup synchronous
+    // also ensures refreshPorts()/prepare() below see the final port count, so the
+    // node's RMS meter buffers are sized correctly.
+    auto* const added = nodes.add (newNode);
     newNode->setPlayHead (playhead);
     newNode->setParentGraph (this);
     newNode->refreshPorts();
     if (prepared())
         newNode->prepare (getSampleRate(), getBlockSize(), this);
     triggerAsyncUpdate();
-    return nodes.add (newNode);
+    return added;
 }
 
 bool GraphNode::removeNode (const uint32 nodeId)

--- a/src/engine/ionode.cpp
+++ b/src/engine/ionode.cpp
@@ -193,7 +193,12 @@ void IONode::setParentGraph (GraphNode* const newGraph)
         if (currentCount == 0)
         {
             const int defaultCount = (portType == PortType::Audio) ? 2 : 1;
-            graph->setNumPorts (portType, defaultCount, isInput(), false);
+            // NB: use the async path. A synchronous port reset here fires
+            // portsChanged() while we're still inside GraphNode::addNode (before
+            // this node is registered in the runtime nodes array), which makes a
+            // re-entrant IONodeEnforcer think this IO node is missing and add a
+            // duplicate. Deferring lets the add complete first.
+            graph->setNumPorts (portType, defaultCount, isInput(), true);
         }
     }
 

--- a/src/engine/ionode.cpp
+++ b/src/engine/ionode.cpp
@@ -193,12 +193,7 @@ void IONode::setParentGraph (GraphNode* const newGraph)
         if (currentCount == 0)
         {
             const int defaultCount = (portType == PortType::Audio) ? 2 : 1;
-            // NB: use the async path. A synchronous port reset here fires
-            // portsChanged() while we're still inside GraphNode::addNode (before
-            // this node is registered in the runtime nodes array), which makes a
-            // re-entrant IONodeEnforcer think this IO node is missing and add a
-            // duplicate. Deferring lets the add complete first.
-            graph->setNumPorts (portType, defaultCount, isInput(), true);
+            graph->setNumPorts (portType, defaultCount, isInput(), false);
         }
     }
 

--- a/src/engine/processor.cpp
+++ b/src/engine/processor.cpp
@@ -663,6 +663,28 @@ void Processor::setPorts (const PortList& newPorts)
     parameters.swapWith (newParams);
     newParamsOut.sort (sorter, true);
     parametersOut.swapWith (newParamsOut);
+
+    // Keep the RMS metering buffers in sync with the (possibly changed) channel
+    // counts. prepare() sizes these once, but an IO node's channel count can grow
+    // later (e.g. raising a graph's Audio Out count via the +/- controls), which
+    // refreshes ports without re-preparing. Grow-only: never drop a slot the audio
+    // or UI threads may still be reading.
+    if (isPrepared)
+    {
+        for (int i = inRMS.size(); i < getNumAudioInputs(); ++i)
+        {
+            auto* avf = new AtomicValue<float>();
+            avf->set (0);
+            inRMS.add (avf);
+        }
+
+        for (int i = outRMS.size(); i < getNumAudioOutputs(); ++i)
+        {
+            auto* avf = new AtomicValue<float>();
+            avf->set (0);
+            outRMS.add (avf);
+        }
+    }
 }
 
 ValueTree Processor::createPortsData() const


### PR DESCRIPTION
### Problem
After deleting a graph's Audio Out node and re-adding it during a session, two issues appeared:
1. **Duplicate nodes** — re-adding via the GraphEditor right-click menu ("Graph I/O → Audio Outputs") produced **two** Audio Out nodes.
2. **Dead meters** — re-adding (especially via the navigation Graph panel's +/- channel controls) gave working audio but frozen/partial level meters.

### Root causes
- **Duplication:** `IONode::setParentGraph` synchronously set the parent graph's port count, which re-entered `IONodeEnforcer` *before* the in-flight node was registered in the graph's node array. The enforcer saw no Audio Out node and added a second one.
- **Dead meters:** A node's RMS metering buffers (`inRMS`/`outRMS`) were sized only in `prepare()`. Growing a graph's channel count refreshes the IO node's ports without re-preparing, so the meter buffers stayed at the old size — e.g. only channel 1 had a slot.

### Changes
- `GraphNode::addNode` — register the node in the graph array *before* `setParentGraph`, so the re-entrant enforcer sees it and won't duplicate. Port setup stays synchronous so ports/RMS are sized correctly.
- `IONodeEnforcer` — dedupe safety net: collapse any extra IO nodes of the same type, repairing sessions already corrupted by the bug.
- `Processor::setPorts` — grow the RMS buffers to match the new channel counts when ports change on a prepared node (grow-only, so no slot in use by the audio/UI threads is freed).

### Testing
Verified manually: delete + re-add Audio Out via both the right-click menu and the Graph panel +/- controls yields a single node with all channel meters live; raising an existing Audio Out's channel count meters the new channels too.
