### PR TITLE
Add Close Session Action to Menu

### DIFF
--- a/src/engine/audioengine.cpp
+++ b/src/engine/audioengine.cpp
@@ -655,6 +655,10 @@ public:
         {
             ScopedLock sl (lock);
             graphs.removeGraph (graph);
+            // keep the requested index valid, otherwise a stale index gets
+            // written back into the session model by onCurrentGraphChanged()
+            if (currentGraph.get() >= graphs.size())
+                currentGraph.set (graphs.size() - 1);
         }
 
         graph->renderingSequenceChanged.disconnect_all_slots();

--- a/src/services/sessionservice.cpp
+++ b/src/services/sessionservice.cpp
@@ -221,9 +221,11 @@ bool SessionService::hasSessionChanged()
 
 void SessionService::resetChanges (const bool resetDocumentFile)
 {
-    jassert (document);
+    jassert (document && currentSession);
     if (resetDocumentFile)
         document->setFile ({});
+    // flush pending change messages so they don't re-flag the document afterwards
+    currentSession->dispatchPendingMessages();
     document->setChangedFlag (false);
     jassert (! document->hasChangedSinceSaved());
 }

--- a/src/services/sessionservice.cpp
+++ b/src/services/sessionservice.cpp
@@ -177,7 +177,41 @@ void SessionService::importGraph (const File& file)
 
 void SessionService::closeSession()
 {
-    DBG ("[SC] close session");
+    jassert (document && currentSession);
+    if (! saveIfNeededAndUserAgrees())
+        return;
+
+    sibling<GuiService>()->closeAllPluginWindows();
+    currentSession->clear();
+    refreshOtherControllers();
+    sibling<GuiService>()->stabilizeContent();
+    resetChanges (true);
+}
+
+bool SessionService::saveIfNeededAndUserAgrees()
+{
+    jassert (document);
+    if (! document->hasChangedSinceSaved())
+        return true;
+
+    // - 0 if the third button was pressed ('cancel')
+    // - 1 if the first button was pressed ('yes')
+    // - 2 if the middle button was pressed ('no')
+    const int res = AlertWindow::showYesNoCancelBox (AlertWindow::InfoIcon,
+                                                     "Save Session?",
+                                                     "The current session has changes. Would you like to save it?",
+                                                     "Save Session",
+                                                     "Don't Save",
+                                                     "Cancel");
+    switch (res)
+    {
+        case 1: // save: only proceed if the save actually completed
+            return document->save (true, true) == FileBasedDocument::savedOk;
+        case 2: // don't save
+            return true;
+        default: // cancel
+            return false;
+    }
 }
 
 bool SessionService::hasSessionChanged()
@@ -245,28 +279,14 @@ void SessionService::saveSession (const bool saveAs, const bool askForFile, cons
 void SessionService::newSession()
 {
     jassert (document && currentSession);
-    // - 0 if the third button was pressed ('cancel')
-    // - 1 if the first button was pressed ('yes')
-    // - 2 if the middle button was pressed ('no')
-    int res = 2;
-    if (document->hasChangedSinceSaved())
-        res = AlertWindow::showYesNoCancelBox (AlertWindow::InfoIcon,
-                                               "Save Session?",
-                                               "The current session has changes. Would you like to save it?",
-                                               "Save Session",
-                                               "Don't Save",
-                                               "Cancel");
-    if (res == 1)
-        document->save (true, true);
+    if (! saveIfNeededAndUserAgrees())
+        return;
 
-    if (res == 1 || res == 2)
-    {
-        sibling<GuiService>()->closeAllPluginWindows();
-        loadNewSessionData();
-        refreshOtherControllers();
-        sibling<GuiService>()->stabilizeContent();
-        resetChanges (true);
-    }
+    sibling<GuiService>()->closeAllPluginWindows();
+    loadNewSessionData();
+    refreshOtherControllers();
+    sibling<GuiService>()->stabilizeContent();
+    resetChanges (true);
 }
 
 void SessionService::loadNewSessionData()

--- a/src/services/sessionservice.hpp
+++ b/src/services/sessionservice.hpp
@@ -22,6 +22,12 @@ public:
     void openDefaultSession();
     void openFile (const File& file);
     const File getSessionFile() const;
+
+    /** Closes the current session, leaving an empty, untitled session.
+
+        Prompts to save first if the session has unsaved changes. Does nothing
+        if the user cancels.
+    */
     void closeSession();
     void saveSession (const bool saveAs = false,
                       const bool askForFile = true,
@@ -45,6 +51,13 @@ private:
 
     void loadNewSessionData();
     void refreshOtherControllers();
+
+    /** Asks the user to save the session if it has unsaved changes.
+
+        @return true if it is ok to discard or replace the current session,
+                false if the user cancelled
+    */
+    bool saveIfNeededAndUserAgrees();
 };
 
 } // namespace element

--- a/src/ui/mainmenu.cpp
+++ b/src/ui/mainmenu.cpp
@@ -244,6 +244,7 @@ void MainMenu::addRecentFiles (PopupMenu& menu)
 void MainMenu::buildFileMenu (PopupMenu& menu)
 {
     menu.addCommandItem (&cmd, Commands::sessionNew, "New Session");
+    menu.addCommandItem (&cmd, Commands::sessionClose, "Close Session");
     menu.addSeparator();
     menu.addCommandItem (&cmd, Commands::sessionOpen, "Open Session...");
     addRecentFiles (menu);
@@ -331,6 +332,7 @@ void MainMenu::buildHelpMenu (PopupMenu& menu)
 void MainMenu::buildSessionMenu (Commands& cmd, PopupMenu& menu)
 {
     menu.addCommandItem (&cmd, Commands::sessionNew, "New Session");
+    menu.addCommandItem (&cmd, Commands::sessionClose, "Close Session");
     menu.addSeparator();
 
     menu.addCommandItem (&cmd, Commands::sessionOpen, "Open Session...");


### PR DESCRIPTION
Using it closes and unloads the current session; does not create a new one.

Fixes #867 